### PR TITLE
Bug: 로그인/회원가입 시 응답 url에 userId 추가 (#70)

### DIFF
--- a/src/main/java/tavebalak/OTTify/oauth/CustomOAuth2User.java
+++ b/src/main/java/tavebalak/OTTify/oauth/CustomOAuth2User.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
+    private Long userId;
     private String email;
     private Role role;
 
@@ -22,8 +23,9 @@ public class CustomOAuth2User extends DefaultOAuth2User {
      * @param nameAttributeKey the key used to access the user's &quot;name&quot; from
      *                         {@link #getAttributes()}
      */
-    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey, String email, Role role) {
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey, Long userId, String email, Role role) {
         super(authorities, attributes, nameAttributeKey);
+        this.userId = userId;
         this.email = email;
         this.role = role;
     }

--- a/src/main/java/tavebalak/OTTify/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/tavebalak/OTTify/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -9,7 +9,9 @@ import tavebalak.OTTify.common.constant.Role;
 import tavebalak.OTTify.oauth.CustomOAuth2User;
 import tavebalak.OTTify.oauth.jwt.JwtService;
 import tavebalak.OTTify.oauth.redis.RefreshTokenRepository;
+import tavebalak.OTTify.user.entity.User;
 import tavebalak.OTTify.user.repository.UserRepository;
+import tavebalak.OTTify.user.service.UserService;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -35,10 +37,12 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
             if(oAuth2User.getRole() == Role.GUEST) {
                 String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
                 String refreshToken = jwtService.createRefreshToken();
+                Long userId = oAuth2User.getUserId();
 
                 response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
                 response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
-                String url = generateUrl(accessToken, refreshToken);
+
+                String url = generateUrl(accessToken, refreshToken, userId);
 //                response.sendRedirect("oauth2/sign-up"); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트
 
                 jwtService.sendAccessAndRefreshToken(response, oAuth2User.getEmail(), accessToken, refreshToken);
@@ -62,10 +66,12 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
     private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
         String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
         String refreshToken = jwtService.createRefreshToken();
+        Long userId = oAuth2User.getUserId();
+
         response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
         response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
 
-        String url = generateUrl(accessToken, refreshToken);
+        String url = generateUrl(accessToken, refreshToken, userId);
         log.info("===redirect===");
 
         jwtService.sendAccessAndRefreshToken(response, oAuth2User.getEmail(), accessToken, refreshToken);
@@ -75,7 +81,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 
     }
 
-    private String generateUrl(final String accessToken, final String refreshToken) {
+    private String generateUrl(final String accessToken, final String refreshToken, final Long userId) {
         StringBuilder sb = new StringBuilder();
         StringBuilder url = sb.append("http://52.79.200.90:3000/login/oauth2/code")
                 .append("?")
@@ -83,7 +89,10 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                 .append(accessToken)
                 .append("&")
                 .append("refreshToken=")
-                .append(refreshToken);
+                .append(refreshToken)
+                .append("&")
+                .append("userId=")
+                .append(userId);
         return url.toString();
     }
 }

--- a/src/main/java/tavebalak/OTTify/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/tavebalak/OTTify/oauth/service/CustomOAuth2UserService.java
@@ -50,6 +50,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 Collections.singleton(new SimpleGrantedAuthority(createdUser.getRole().getKey())),
                 attributes,
                 extractAttributes.getNameAttributeKey(),
+                createdUser.getId(),
                 createdUser.getEmail(),
                 createdUser.getRole()
         );


### PR DESCRIPTION
## 🔥 Related Issue
- Close #70 

## 🏃‍ Task
- 로그인/회원가입 시 응답 url에 userId 추가 📍 관련커밋: {1305920}
-> url로 userId 넘어오는거 확인했습니다.

## 📄 Reference
- https://green-bin.tistory.com/27

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?