### PR TITLE
Bug : @PathParam으로 잘못 사용된 어노테이션 변경(#72)

### DIFF
--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -7,7 +7,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import java.io.IOException;
 import javax.validation.Valid;
-import javax.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tavebalak.OTTify.common.BaseResponse;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
@@ -75,7 +75,7 @@ public class CommunityController {
     @ApiImplicitParam(name = "subjectId", dataType = "long", value = "토론 주제 id", required = true, paramType = "path")
     @ApiResponse(code = 200, message = "성공적으로 토론 게시글 공감 해제가 적용되었습니다.")
     @PostMapping("/like")
-    public BaseResponse<String> likeSubject(@PathParam("subjectId") Long subjectId) {
+    public BaseResponse<String> likeSubject(@RequestParam("subjectId") Long subjectId) {
         boolean hasLiked = communityService.likeSubject(subjectId);
         if (hasLiked) {
             return BaseResponse.success("성공적으로 토론 게시글 공감이 적용이 되었습니다.");
@@ -91,8 +91,8 @@ public class CommunityController {
     @ApiResponse(code = 200, message = "성공적으로 토론 댓글 공감이 적용/해제되었습니다.")
     @PostMapping("/like/comment")
     public BaseResponse<String> likeComment(
-        @PathParam("subjectId") Long subjectId,
-        @PathParam("commentId") Long commentId) {
+        @RequestParam("subjectId") Long subjectId,
+        @RequestParam("commentId") Long commentId) {
         boolean hasLiked = communityService.likeComment(subjectId, commentId);
         if (hasLiked) {
             return BaseResponse.success("성공적으로 토론 댓글 공감 적용이 되었습니다.");
@@ -123,7 +123,8 @@ public class CommunityController {
         @ApiImplicitParam(name = "page", dataType = "int", value = "페이지 번호(0부터 시작)", required = false, paramType = "path"),
         @ApiImplicitParam(name = "direction", dataType = "String", value = "내림차순과 오름차순", required = false, paramType = "path"),
         @ApiImplicitParam(name = "sort", dataType = "String", value = "정렬기준(createdAt, updatedAt)", required = false, paramType = "path"),
-        @ApiImplicitParam(name = "size", dataType = "int", value = "페이지당 아이템 갯수", required = false, paramType = "path")
+        @ApiImplicitParam(name = "size", dataType = "int", value = "페이지당 아이템 갯수", required = false, paramType = "path"),
+        @ApiImplicitParam(name = "programId", dataType = "long", value = "프로그램 id", required = true, paramType = "path")
     })
     @GetMapping("/program")
     public BaseResponse<CommunitySubjectsDTO> getTotalProgramSubjects(
@@ -131,7 +132,7 @@ public class CommunityController {
             sort = "createdAt",
             direction = Sort.Direction.DESC,
             page = 0) Pageable pageable,
-        @PathParam("programId") Long programId) {
+        @RequestParam("programId") Long programId) {
 
         CommunitySubjectsDTO page = communityService.findSingleProgramSubjects(pageable, programId);
         return BaseResponse.success(page);

--- a/src/main/java/tavebalak/OTTify/review/controller/ReviewMainController.java
+++ b/src/main/java/tavebalak/OTTify/review/controller/ReviewMainController.java
@@ -5,11 +5,11 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import java.util.List;
-import javax.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tavebalak.OTTify.common.BaseResponse;
 import tavebalak.OTTify.review.dto.response.LatestReviewsDTO;
@@ -34,7 +34,7 @@ public class ReviewMainController {
     @ApiImplicitParam(name = "id", dataType = "long", value = "공감하려고 하는 리뷰의 id", required = true, paramType = "path")
     @ApiResponse(code = 200, message = "id = ? 인 아이디 값을 가진 리뷰에 공감이 적용/해제되었습니다.")
     @PostMapping("/latestReviews/like")
-    public BaseResponse<String> likeReview(@PathParam("id") Long id) {
+    public BaseResponse<String> likeReview(@RequestParam("id") Long id) {
         boolean hasSaved = reviewService.likeReview(id);
         if (hasSaved) {
             return BaseResponse.success("id = " + id + "인 아이디 값을 가진 리뷰에 공감이 적용되었습니다.");

--- a/src/main/java/tavebalak/OTTify/review/service/ReviewServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/review/service/ReviewServiceImpl.java
@@ -1,9 +1,17 @@
 package tavebalak.OTTify.review.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tavebalak.OTTify.error.ErrorCode;
+import tavebalak.OTTify.error.exception.NotFoundException;
 import tavebalak.OTTify.oauth.jwt.SecurityUtil;
 import tavebalak.OTTify.review.dto.response.LatestReviewsDTO;
 import tavebalak.OTTify.review.entity.Review;
@@ -13,36 +21,35 @@ import tavebalak.OTTify.user.entity.User;
 import tavebalak.OTTify.user.repository.LikedReviewRepository;
 import tavebalak.OTTify.user.repository.UserRepository;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ReviewServiceImpl  implements  ReviewService{
+public class ReviewServiceImpl implements ReviewService {
+
     private final ReviewRepository reviewRepository;
     private final LikedReviewRepository likedReviewRepository;
     private final UserRepository userRepository;
     private final int TOP8_SIZE = 8;
+
     public List<LatestReviewsDTO> getLatestReviews() {
-        List<Review> reviewList = reviewRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Review> reviewList = reviewRepository.findAll(
+            Sort.by(Sort.Direction.DESC, "createdAt"));
         List<Review> top8ReviewList = new ArrayList<>();
-        if(reviewList.size()< TOP8_SIZE){
+        if (reviewList.size() < TOP8_SIZE) {
             top8ReviewList.addAll(reviewList);
-        }else{
+        } else {
             top8ReviewList.addAll(reviewList.subList(0, TOP8_SIZE));
         }
         return top8ReviewList.stream().map(
-                listOne -> LatestReviewsDTO.builder()
-                        .reviewId(listOne.getId())
-                        .nickName(listOne.getUser().getNickName())
-                        .content(listOne.getContent())
-                        .programTitle(listOne.getProgram().getTitle())
-                        .userRating(listOne.getRating())
-                        .profilePhoto(listOne.getUser().getProfilePhoto())
-                        .likeCount(getLikeSum(listOne.getId()))
-                        .build()
+            listOne -> LatestReviewsDTO.builder()
+                .reviewId(listOne.getId())
+                .nickName(listOne.getUser().getNickName())
+                .content(listOne.getContent())
+                .programTitle(listOne.getProgram().getTitle())
+                .userRating(listOne.getRating())
+                .profilePhoto(listOne.getUser().getProfilePhoto())
+                .likeCount(getLikeSum(listOne.getId()))
+                .build()
         ).collect(Collectors.toList());
 
     }
@@ -50,34 +57,35 @@ public class ReviewServiceImpl  implements  ReviewService{
     private Integer getLikeSum(Long reviewId) {
         Optional<List<LikedReview>> likedReviews = likedReviewRepository.findByReviewId(reviewId);
         return likedReviews
-                .map(List::size)
-                .orElse(0);
+            .map(List::size)
+            .orElse(0);
     }
 
     public List<LatestReviewsDTO> getLatestReviewsTest() {
-        List<Review> reviewList = reviewRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Review> reviewList = reviewRepository.findAll(
+            Sort.by(Sort.Direction.DESC, "createdAt"));
         List<Review> top8ReviewList = new ArrayList<>();
-        if(reviewList.size()< TOP8_SIZE){
+        if (reviewList.size() < TOP8_SIZE) {
             top8ReviewList.addAll(reviewList);
-        }else{
+        } else {
             top8ReviewList.addAll(reviewList.subList(0, TOP8_SIZE));
         }
         return top8ReviewList.stream().map(
-                listOne -> LatestReviewsDTO.builder()
-                        .reviewId(listOne.getId())
-                        .nickName(listOne.getUser().getNickName())
-                        .content(listOne.getContent())
-                        .programTitle(listOne.getProgram().getTitle())
-                        .userRating(listOne.getRating())
-                        .profilePhoto(listOne.getUser().getProfilePhoto())
-                        .likeCount(0)
-                        .build()
+            listOne -> LatestReviewsDTO.builder()
+                .reviewId(listOne.getId())
+                .nickName(listOne.getUser().getNickName())
+                .content(listOne.getContent())
+                .programTitle(listOne.getProgram().getTitle())
+                .userRating(listOne.getRating())
+                .profilePhoto(listOne.getUser().getProfilePhoto())
+                .likeCount(0)
+                .build()
         ).collect(Collectors.toList());
 
     }
 
 
-    public void save(Review review){
+    public void save(Review review) {
         reviewRepository.save(review);
     }
 
@@ -85,20 +93,24 @@ public class ReviewServiceImpl  implements  ReviewService{
     public boolean likeReview(Long id) {
         AtomicBoolean flag = new AtomicBoolean(false);
         String userEmail = SecurityUtil.getCurrentEmail().get();
-        User savedUser = userRepository.findByEmail(userEmail).orElseThrow(NoSuchElementException::new);
-        Review review = reviewRepository.findById(id).orElseThrow(NoSuchElementException::new);
-        likedReviewRepository.findByUserIdAndReviewId(savedUser.getId(), review.getId()).ifPresentOrElse(
+        User savedUser = userRepository.findByEmail(userEmail)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+        Review review = reviewRepository.findById(id).orElseThrow(() -> new NotFoundException(
+            ErrorCode.REVIEW_NOT_FOUND));
+        likedReviewRepository.findByUserIdAndReviewId(savedUser.getId(), review.getId())
+            .ifPresentOrElse(
                 likedReviewRepository::delete,
                 () -> {
                     likedReviewRepository.save(
-                            LikedReview.builder()
-                                    .user(savedUser)
-                                    .review(reviewRepository.findById(id).orElseThrow(NoSuchElementException::new))
-                                    .build()
+                        LikedReview.builder()
+                            .user(savedUser)
+                            .review(reviewRepository.findById(id)
+                                .orElseThrow(NoSuchElementException::new))
+                            .build()
                     );
                     flag.set(true);
                 }
-        );
+            );
 
         return flag.get();
     }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #72 

## 🏃‍ Task
- @PathParam 대신 @RequestParam으로 변경 📍 관련커밋: {eb4496bb4d0265c1c0bfef16fd7e59378302570e}
@PathParam은 URL로 고유한 자원(리소스, 데이터)를 지칭할 수 있고, 특정 자원을 가리키는 URL 경로에 가변적인 부분이 있다면 변수로 지정할 수 있습니다. 변수로 지정하더라도 특정 리소스를 가리키는 URI로서 역할은 유지된다고 합니다. 
@RequestParam은 컨트롤러에서 파라미터 값을 넘겨받을때 사용해서 전달인자를 처리하는 방법이라고 합니다.

## 📄 Reference
- https://velog.io/@juno97/API-Path-parameter-VS-Query-Parameter-%EA%B8%B0%EB%A1%9D%EC%9A%A9

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?