### PR TITLE
Refactor : 추천 프로그램에서 평균 별점 제거, 장르 리스트 반환(#93)

### DIFF
--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@ApiModel(value = "CommunitySubjectEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용, 프로그램id, 프로그램 제목, 프로그램 url 내용을 가진 Domain Class")
+@ApiModel(value = "CommunitySubjectEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용을 가진 Domain Class")
 public class CommunitySubjectEditDTO {
 
     @NotNull
@@ -22,16 +22,11 @@ public class CommunitySubjectEditDTO {
     @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
     @ApiModelProperty(value = "토론 내용")
     private String content;
-    @NotNull
-    @ApiModelProperty(value = "프로그램 id")
-    private Long programId;
 
     @Builder
-    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content,
-        Long programId) {
+    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content) {
         this.subjectId = subjectId;
         this.subjectName = subjectName;
         this.content = content;
-        this.programId = programId;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -97,10 +97,6 @@ public class CommunityServiceImpl implements CommunityService {
             throw new BadRequestException(ErrorCode.BAD_REQUEST);
         }
 
-        Program program = programRepository.findById(c.getProgramId())
-            .orElseThrow(() -> new NotFoundException(
-                ErrorCode.SAVED_PROGRAM_NOT_FOUND));
-
         CommunitySubjectEditorDTO communitySubjectEditorDTOBuilder = community.toEditor();
         CommunitySubjectEditorDTO communitySubjectEditorDTO = communitySubjectEditorDTOBuilder.changeTitleContentProgram(
             c.getSubjectName(), c.getContent());
@@ -110,9 +106,6 @@ public class CommunityServiceImpl implements CommunityService {
     public Community modify(CommunitySubjectEditDTO c, User user) throws NotFoundException {
         Community community = communityRepository.findById(c.getSubjectId())
             .orElseThrow(() -> new NotFoundException(ErrorCode.COMMUNITY_NOT_FOUND));
-
-        Program program = programRepository.findById(c.getProgramId())
-            .orElseThrow(() -> new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND));
 
         if (!Objects.equals(community.getUser().getId(), user.getId())) {
             throw new BadRequestException(ErrorCode.BAD_REQUEST);

--- a/src/main/java/tavebalak/OTTify/program/dto/response/ServiceListsDTO.java
+++ b/src/main/java/tavebalak/OTTify/program/dto/response/ServiceListsDTO.java
@@ -2,13 +2,14 @@ package tavebalak.OTTify.program.dto.response;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@ApiModel(value = "ServiceListsDTO(프로그램 정보)", description = "프로그램 id, 프로그램 제목, 포스터 url, 평균 펼점 내용을 가진 Domain Class")
+@ApiModel(value = "ServiceListsDTO(프로그램 정보)", description = "프로그램 id, 프로그램 제목, 포스터 url, 장르 리스트 내용을 가진 Domain Class")
 public class ServiceListsDTO {
 
     @ApiModelProperty(value = "프로그램 id")
@@ -17,18 +18,18 @@ public class ServiceListsDTO {
     private String title;
     @ApiModelProperty(value = "포스터 url")
     private String posterPath;
-    @ApiModelProperty(value = "평균 펼점")
-    private double averageRating;
     @ApiModelProperty(value = "개봉년도")
     private String createdYear;
+    @ApiModelProperty(value = "장르 리스트")
+    private List<String> genreNameList;
 
     @Builder
-    public ServiceListsDTO(Long programId, String title, String posterPath, double averageRating,
-        String createdYear) {
+    public ServiceListsDTO(Long programId, String title, String posterPath,
+        String createdYear, List<String> genreNameList) {
         this.programId = programId;
         this.title = title;
         this.posterPath = posterPath;
-        this.averageRating = averageRating;
+        this.genreNameList = genreNameList;
         this.createdYear = createdYear;
     }
 }

--- a/src/main/java/tavebalak/OTTify/program/service/ProgramService.java
+++ b/src/main/java/tavebalak/OTTify/program/service/ProgramService.java
@@ -3,5 +3,6 @@ package tavebalak.OTTify.program.service;
 import tavebalak.OTTify.program.dto.response.RecommendProgramsDTO;
 
 public interface ProgramService {
-    public RecommendProgramsDTO getRecommendProgram(int count);
+
+    RecommendProgramsDTO getRecommendProgram(int count);
 }

--- a/src/main/java/tavebalak/OTTify/program/service/ProgramServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/program/service/ProgramServiceImpl.java
@@ -133,10 +133,19 @@ public class ProgramServiceImpl implements ProgramService {
                         .programId(pg.getId())
                         .title(pg.getTitle())
                         .posterPath(pg.getPosterPath())
-                        .averageRating(pg.getAverageRating())
                         .createdYear(pg.getCreatedYear())
+                        .genreNameList(findGenreList(pg))
                         .build()).collect(Collectors.toList())
             ).build();
+    }
+
+    private List<String> findGenreList(Program pg) {
+        return programGenreRepository.findByProgram(pg.getId())
+            .stream()
+            .map(programGenre -> genreRepository.findById(programGenre.getGenre().getId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.GENRE_NOT_FOUND))
+                .getName())
+            .collect(Collectors.toList());
     }
 
     private User getUser() {

--- a/src/main/java/tavebalak/OTTify/review/controller/ReviewMainController.java
+++ b/src/main/java/tavebalak/OTTify/review/controller/ReviewMainController.java
@@ -32,7 +32,7 @@ public class ReviewMainController {
 
     @ApiOperation(value = "최신리뷰 공감 적용/해제", notes = "회원이 작성한 리뷰에 대해 공감/해제한다.")
     @ApiResponse(code = 200, message = "id = ? 인 아이디 값을 가진 리뷰에 공감이 적용/해제되었습니다.")
-    @ApiImplicitParam(name = "id", value = "프로그램 ID 값", required = true, paramType = "query")
+    @ApiImplicitParam(name = "id", value = "리뷰 ID 값", required = true, paramType = "query")
     @PostMapping("/latestReviews/like")
     public BaseResponse<String> likeReview(@RequestParam("id") Long id) {
         boolean hasSaved = reviewService.likeReview(id);

--- a/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
+++ b/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
@@ -254,7 +254,6 @@ class CommunityControllerTest {
             .subjectId(savedCommunity.getId())
             .content(savedCommunity.getContent())
             .subjectName(savedCommunity.getTitle())
-            .programId(savedCommunity.getProgram().getId())
             .build();
 
         //when


### PR DESCRIPTION
## 🔥 Related Issue
- Close #93 

## 🏃‍ Task
- 추천 프로그램에서 평균 별점 제거, 장르 리스트 반환📍 관련커밋: {dd1cec4bd8ebc548ee1371f252527e7e1ad7b007}
피그마에서는 장르 하나만 제시되는데, db를 보니 장르가 여러 개인 것이 많아서 리스트로 제공하는 걸로 했어요
제가 장르 이름 하나만 보내도 되지만 장르 이름에서 우선순위를 따지기 어려워서 리스트로 했습니다

<p float="left">
  <img src="https://github.com/TAVE-balak/OTTify-backend/assets/96781855/4ee792ae-6e24-4c27-8583-fdeb9ef2ee9f" ㅗheight="300" />
  <img src="https://github.com/TAVE-balak/OTTify-backend/assets/96781855/5984c8e8-0ba7-4a3a-87e0-2f60eae907c8" height="300" />
</p>



## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?