### PR TITLE
Refactor: 엑세스 토큰을 통해 가져온 유저가 없을 경우 Notfound->Unauthorized로 변경 (#91)

### DIFF
--- a/src/main/java/tavebalak/OTTify/program/controller/ProgramChoiceController.java
+++ b/src/main/java/tavebalak/OTTify/program/controller/ProgramChoiceController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import tavebalak.OTTify.common.BaseResponse;
 import tavebalak.OTTify.error.ErrorCode;
-import tavebalak.OTTify.error.exception.NotFoundException;
+import tavebalak.OTTify.error.exception.UnauthorizedException;
 import tavebalak.OTTify.oauth.jwt.SecurityUtil;
 import tavebalak.OTTify.program.service.ProgramChoiceService;
 import tavebalak.OTTify.user.entity.User;
@@ -53,6 +53,6 @@ public class ProgramChoiceController {
 
     private User getUser() {
         return userRepository.findByEmail(SecurityUtil.getCurrentEmail().get())
-            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.UNAUTHORIZED));
     }
 }

--- a/src/main/java/tavebalak/OTTify/review/controller/ReviewCUDController.java
+++ b/src/main/java/tavebalak/OTTify/review/controller/ReviewCUDController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import tavebalak.OTTify.common.BaseResponse;
 import tavebalak.OTTify.error.ErrorCode;
-import tavebalak.OTTify.error.exception.NotFoundException;
+import tavebalak.OTTify.error.exception.UnauthorizedException;
 import tavebalak.OTTify.oauth.jwt.SecurityUtil;
 import tavebalak.OTTify.review.dto.reviewrequest.ReviewSaveDto;
 import tavebalak.OTTify.review.dto.reviewrequest.ReviewUpdateDto;
@@ -81,6 +81,6 @@ public class ReviewCUDController {
 
     private User getUser() {
         return userRepository.findByEmail(SecurityUtil.getCurrentEmail().get())
-            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.UNAUTHORIZED));
     }
 }

--- a/src/main/java/tavebalak/OTTify/review/controller/ReviewShowProgramDetailController.java
+++ b/src/main/java/tavebalak/OTTify/review/controller/ReviewShowProgramDetailController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import tavebalak.OTTify.common.BaseResponse;
 import tavebalak.OTTify.error.ErrorCode;
-import tavebalak.OTTify.error.exception.NotFoundException;
+import tavebalak.OTTify.error.exception.UnauthorizedException;
 import tavebalak.OTTify.oauth.jwt.SecurityUtil;
 import tavebalak.OTTify.review.dto.reviewresponse.ReviewProgramResponseDto;
 import tavebalak.OTTify.review.dto.reviewresponse.ReviewResponseDtoList;
@@ -111,6 +111,6 @@ public class ReviewShowProgramDetailController {
 
     private User getUser() {
         return userRepository.findByEmail(SecurityUtil.getCurrentEmail().get())
-            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.UNAUTHORIZED));
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #91 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}
- 컨트롤러 단의 AccessToken 을 통해 접근 권한이 없을 때의 오류 메시지를 NotFound-> UnAuthorized로 변경 

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?