### PR TITLE
Bug/#107 update profile photo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
-	dependencies {
-		classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:1.0.10")
-	}
+    dependencies {
+        classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:1.0.10")
+    }
 }
 
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.17'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.17'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 apply plugin: "com.ewerk.gradle.plugins.querydsl"
@@ -16,67 +16,68 @@ group = 'study'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
-	implementation 'com.google.code.gson:gson'
-	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
-	implementation 'io.springfox:springfox-swagger2:2.9.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
+    implementation 'com.google.code.gson:gson'
+    implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+    implementation 'io.springfox:springfox-swagger2:2.9.2'
 
-	//mysql 추가
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	//h2 추가
-	runtimeOnly 'com.h2database:h2'
+    //mysql 추가
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    //h2 추가
+    runtimeOnly 'com.h2database:h2'
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-
-
-	//oauth
-	implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
-
-	//jwt
-	implementation 'com.auth0:java-jwt:4.2.1'
-
-	//redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
 
+    //oauth
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
 
-	implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    //jwt
+    implementation 'com.auth0:java-jwt:4.2.1'
 
-	//querydsl 추가
-	implementation 'com.querydsl:querydsl-jpa'
-	implementation 'com.querydsl:querydsl-apt'
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //aws S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
+
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa'
+    implementation 'com.querydsl:querydsl-apt'
 
 
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // submodules 관련 설정
@@ -90,11 +91,11 @@ tasks.named('test') {
 //}
 
 task copyPrivate(type: Copy) {
-	copy {
-		from './submodule-config'
-		include "*.yml"
-		into 'src/main/resources'
-	}
+    copy {
+        from './submodule-config'
+        include "*.yml"
+        into 'src/main/resources'
+    }
 }
 
 
@@ -102,22 +103,23 @@ task copyPrivate(type: Copy) {
 def querydslDir = 'src/main/generated'
 
 querydsl {
-	library = "com.querydsl:querydsl-apt"
-	jpa = true
-	querydslSourcesDir = querydslDir
+    library = "com.querydsl:querydsl-apt"
+    jpa = true
+    querydslSourcesDir = querydslDir
 }
 
 sourceSets {
-	main {
-		java {
-			srcDirs = ['src/main/java', querydslDir]
-		} }
+    main {
+        java {
+            srcDirs = ['src/main/java', querydslDir]
+        }
+    }
 }
 
-compileQuerydsl{
-	options.annotationProcessorPath = configurations.querydsl
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 
 configurations {
-	querydsl.extendsFrom compileClasspath
+    querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/tavebalak/OTTify/common/config/S3Config.java
+++ b/src/main/java/tavebalak/OTTify/common/config/S3Config.java
@@ -1,0 +1,33 @@
+package tavebalak.OTTify.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+    }
+}

--- a/src/main/java/tavebalak/OTTify/common/s3/AWSS3Service.java
+++ b/src/main/java/tavebalak/OTTify/common/s3/AWSS3Service.java
@@ -24,6 +24,9 @@ public class AWSS3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    @Value("${cloud.aws.s3.url}")
+    private String url;
+
     private final AmazonS3Client amazonS3Client;
 
     public String upload(MultipartFile multipartFile, String dirName) {
@@ -49,4 +52,17 @@ public class AWSS3Service {
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
+    public void delete(String fileRoute) {
+        int index = fileRoute.indexOf(url);
+        String fileName = fileRoute.substring(index + url.length() + 1);
+
+        try {
+            boolean isObjectExist = amazonS3Client.doesObjectExist(bucket, fileName);
+            if (isObjectExist) {
+                amazonS3Client.deleteObject(bucket, fileName);
+            }
+        } catch (Exception e) {
+            throw new InternalServerErrorException(ErrorCode.FILE_DELETE_FAILED);
+        }
+    }
 }

--- a/src/main/java/tavebalak/OTTify/common/s3/AWSS3Service.java
+++ b/src/main/java/tavebalak/OTTify/common/s3/AWSS3Service.java
@@ -1,0 +1,52 @@
+package tavebalak.OTTify.common.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import tavebalak.OTTify.error.ErrorCode;
+import tavebalak.OTTify.error.exception.BadRequestException;
+import tavebalak.OTTify.error.exception.InternalServerErrorException;
+
+@Service
+@RequiredArgsConstructor
+public class AWSS3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    public String upload(MultipartFile multipartFile, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID() + ".jpg";
+        if (multipartFile.isEmpty()) {
+            throw new BadRequestException(ErrorCode.PROFILE_PHOTO_ISNOT_EXIST);
+        }
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            byte[] bytes = IOUtils.toByteArray(inputStream);
+            objectMetadata.setContentLength(bytes.length);
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, byteArrayInputStream, objectMetadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new InternalServerErrorException(ErrorCode.UPLOAD_FAILED);
+        }
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+}

--- a/src/main/java/tavebalak/OTTify/error/ErrorCode.java
+++ b/src/main/java/tavebalak/OTTify/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
      */
     BAD_REQUEST("잘못된 요청입니다."),
     EMAIL_ISNOT_EXIST("이메일이 없습니다."),
+    PROFILE_PHOTO_ISNOT_EXIST("프로필 사진이 없습니다."),
     CAN_NOT_SELF_LIKE_REVIEW_REQUEST("자신의 리뷰에는 추천할 수 없습니다"),
     CAN_NOT_ALREADY_LIKE_REVIEW_REQUEST("이미 좋아요한 리뷰에는 추천할 수 없습니다"),
     CAN_NOT_SAVE_REVIEW_IN_SAME_PROGRAM("같은 프로그램에는 리뷰를 남길 수 없습니다"),
@@ -48,6 +49,7 @@ public enum ErrorCode {
     SAVED_PROGRAM_NOT_FOUND("저장된 프로그램 정보를 찾을 수 없습니다."),
     COMMUNITY_NOT_FOUND("토론주제를 찾을 수 없습니다."),
     REPLY_NOT_FOUND("댓글을 찾을 수 없습니다."),
+
     /**
      * 405 Method Not Allowed
      */
@@ -62,7 +64,8 @@ public enum ErrorCode {
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR("서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR("서버 내부 오류입니다."),
+    UPLOAD_FAILED("업로드에 실패하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/tavebalak/OTTify/error/ErrorCode.java
+++ b/src/main/java/tavebalak/OTTify/error/ErrorCode.java
@@ -65,7 +65,8 @@ public enum ErrorCode {
      * 500 Internal Server Error
      */
     INTERNAL_SERVER_ERROR("서버 내부 오류입니다."),
-    UPLOAD_FAILED("업로드에 실패하였습니다.");
+    UPLOAD_FAILED("업로드에 실패하였습니다."),
+    FILE_DELETE_FAILED("파일 삭제에 실패하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/tavebalak/OTTify/user/controller/UserController.java
+++ b/src/main/java/tavebalak/OTTify/user/controller/UserController.java
@@ -1,25 +1,35 @@
 package tavebalak.OTTify.user.controller;
 
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import tavebalak.OTTify.common.BaseResponse;
-import tavebalak.OTTify.user.service.UserService;
-import tavebalak.OTTify.user.dto.Request.UserOttUpdateDTO;
-import tavebalak.OTTify.user.dto.Response.UserOttListDTO;
-import tavebalak.OTTify.user.dto.Response.UserProfileDTO;
-import tavebalak.OTTify.user.dto.Request.UserProfileUpdateDTO;
-import tavebalak.OTTify.genre.dto.request.GenreUpdateDTO;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import tavebalak.OTTify.common.BaseResponse;
 import tavebalak.OTTify.community.dto.response.MyDiscussionDto;
+import tavebalak.OTTify.genre.dto.request.GenreUpdateDTO;
 import tavebalak.OTTify.review.dto.response.MyReviewDto;
-
-import java.util.List;
+import tavebalak.OTTify.user.dto.Request.UserOttUpdateDTO;
+import tavebalak.OTTify.user.dto.Request.UserProfileUpdateDTO;
+import tavebalak.OTTify.user.dto.Response.UserOttListDTO;
+import tavebalak.OTTify.user.dto.Response.UserProfileDTO;
+import tavebalak.OTTify.user.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,7 +62,7 @@ public class UserController {
     @PatchMapping("/{userId}/profile")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse updateUserProfile(@PathVariable("userId") Long userId,
-        @Validated @RequestBody UserProfileUpdateDTO updateRequestDTO) {
+        @Validated @ModelAttribute UserProfileUpdateDTO updateRequestDTO) {
         userService.updateUserProfile(userId, updateRequestDTO);
         return BaseResponse.success("성공적으로 프로필이 업데이트 되었습니다.");
     }

--- a/src/main/java/tavebalak/OTTify/user/controller/UserController.java
+++ b/src/main/java/tavebalak/OTTify/user/controller/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -56,10 +57,10 @@ public class UserController {
         return BaseResponse.success(userService.getUserOTT(userId));
     }
 
-    @ApiOperation(value = "프로필 수정 api", notes = "유저 프로필(닉네임, 프로필 사진)을 수정합니다.")
+    @ApiOperation(value = "프로필 수정 api", notes = "유저 프로필(닉네임, 프로필 사진)을 수정합니다. ⚠️ Content-Type를 multipart/form-data로 설정하고 파라미터 별로 MediaType을 설정해 주세요.")
     @ApiImplicitParam(name = "userId", dataType = "long", value = "유저 id", required = true, paramType = "path")
     @ApiResponse(code = 200, message = "성공적으로 프로필이 업데이트 되었습니다.")
-    @PatchMapping("/{userId}/profile")
+    @PatchMapping(value = "/{userId}/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse updateUserProfile(@PathVariable("userId") Long userId,
         @Validated @ModelAttribute UserProfileUpdateDTO updateRequestDTO) {

--- a/src/main/java/tavebalak/OTTify/user/controller/UserController.java
+++ b/src/main/java/tavebalak/OTTify/user/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
         return BaseResponse.success(userService.getUserOTT(userId));
     }
 
-    @ApiOperation(value = "프로필 수정 api", notes = "유저 프로필(닉네임, 프로필 사진)을 수정합니다. ⚠️ Content-Type를 multipart/form-data로 설정하고 파라미터 별로 MediaType을 설정해 주세요.")
+    @ApiOperation(value = "프로필 수정 api", notes = "유저 프로필(닉네임, 프로필 사진)을 수정합니다. ⚠️ Content-Type를 multipart/form-data로 설정하고 파라미터 별로 MediaType을 설정해 주세요. 🚨 swagger 버전 문제로 swagger에서는 해당 api 테스트 불가합니다. postman으로 해주세요 !!! 🚨")
     @ApiImplicitParam(name = "userId", dataType = "long", value = "유저 id", required = true, paramType = "path")
     @ApiResponse(code = 200, message = "성공적으로 프로필이 업데이트 되었습니다.")
     @PatchMapping(value = "/{userId}/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/tavebalak/OTTify/user/dto/Request/UserProfileUpdateDTO.java
+++ b/src/main/java/tavebalak/OTTify/user/dto/Request/UserProfileUpdateDTO.java
@@ -1,5 +1,6 @@
 package tavebalak.OTTify.user.dto.Request;
 
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -11,11 +12,12 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 public class UserProfileUpdateDTO {
 
+    @ApiModelProperty(value = "새로 업데이트 하고자 하는 닉네임", required = true)
     @NotNull(message = "닉네임을 입력해주세요.")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2 ~ 10자리여야 합니다.")
     @Length(min = 2, max = 10, message = "닉네임은 2자 이상, 10자 이하로 입력해주세요")
     private String nickName;
 
-    @NotNull(message = "사진을 업로드해주세요.")
+    @ApiModelProperty(value = "새로 업로드 하고자 하는 프로필 사진")
     private MultipartFile profilePhoto;
 }

--- a/src/main/java/tavebalak/OTTify/user/dto/Request/UserProfileUpdateDTO.java
+++ b/src/main/java/tavebalak/OTTify/user/dto/Request/UserProfileUpdateDTO.java
@@ -2,12 +2,13 @@ package tavebalak.OTTify.user.dto.Request;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class UserProfileUpdateDTO {
 
     @NotNull(message = "닉네임을 입력해주세요.")
@@ -16,5 +17,5 @@ public class UserProfileUpdateDTO {
     private String nickName;
 
     @NotNull(message = "사진을 업로드해주세요.")
-    private String profilePhoto;
+    private MultipartFile profilePhoto;
 }

--- a/src/main/java/tavebalak/OTTify/user/service/UserService.java
+++ b/src/main/java/tavebalak/OTTify/user/service/UserService.java
@@ -1,25 +1,34 @@
 package tavebalak.OTTify.user.service;
 
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import tavebalak.OTTify.community.dto.response.MyDiscussionDto;
+import tavebalak.OTTify.genre.dto.request.GenreUpdateDTO;
 import tavebalak.OTTify.review.dto.response.MyReviewDto;
 import tavebalak.OTTify.user.dto.Request.UserOttUpdateDTO;
 import tavebalak.OTTify.user.dto.Request.UserProfileUpdateDTO;
 import tavebalak.OTTify.user.dto.Response.UserOttListDTO;
 import tavebalak.OTTify.user.dto.Response.UserProfileDTO;
-import tavebalak.OTTify.genre.dto.request.GenreUpdateDTO;
-
-import java.util.List;
 
 public interface UserService {
+
     UserProfileDTO getUserProfile(Long userId);
+
     UserOttListDTO getUserOTT(Long userId);
+
     void update1stGenre(Long userId, GenreUpdateDTO updateRequestDTO);
+
     void update2ndGenre(Long userId, GenreUpdateDTO updateRequestDTO);
+
     Long updateUserProfile(Long userId, UserProfileUpdateDTO updateRequestDTO);
+
     Long updateUserOTT(Long userId, UserOttUpdateDTO updateRequestDTO);
+
     List<MyReviewDto> getMyReview(Long userId, Pageable pageable);
+
     List<MyReviewDto> getLikedReview(Long userId, Pageable pageable);
+
     List<MyDiscussionDto> getHostedDiscussion(Long userId, Pageable pageable);
+
     List<MyDiscussionDto> getParticipatedDiscussion(Long userId, Pageable pageable);
 }

--- a/src/main/java/tavebalak/OTTify/user/service/UserServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/user/service/UserServiceImpl.java
@@ -220,8 +220,14 @@ public class UserServiceImpl implements UserService {
         checkNicknameDuplication(userId, updateRequestDTO);
         user.changeNickName(updateRequestDTO.getNickName());
 
-        String newPhotoUrl = awss3Service.upload(updateRequestDTO.getProfilePhoto(), "profile-images");
-        user.changeProfilePhoto(newPhotoUrl);
+        // 프로필 사진이 존재하는 경우 프로필 사진 변경
+        if (!updateRequestDTO.getProfilePhoto().isEmpty()) {
+            // 이전 프로필 사진 S3에서 삭제
+            awss3Service.delete(user.getProfilePhoto());
+
+            String newPhotoUrl = awss3Service.upload(updateRequestDTO.getProfilePhoto(), "profile-images");
+            user.changeProfilePhoto(newPhotoUrl);
+        }
 
         return userRepository.save(user).getId();
     }

--- a/src/main/java/tavebalak/OTTify/user/service/UserServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/user/service/UserServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tavebalak.OTTify.common.s3.AWSS3Service;
 import tavebalak.OTTify.community.dto.response.MyDiscussionDto;
 import tavebalak.OTTify.community.entity.Community;
 import tavebalak.OTTify.community.repository.CommunityRepository;
@@ -72,6 +73,7 @@ public class UserServiceImpl implements UserService {
     private final GenreRepository genreRepository;
     private final CommunityRepository communityRepository;
     private final ReplyRepository replyRepository;
+    private final AWSS3Service awss3Service;
 
     @Override
     public UserProfileDTO getUserProfile(Long userId) {
@@ -216,9 +218,10 @@ public class UserServiceImpl implements UserService {
 
         // 닉네임 중복 여부 검증
         checkNicknameDuplication(userId, updateRequestDTO);
-
         user.changeNickName(updateRequestDTO.getNickName());
-        user.changeProfilePhoto(updateRequestDTO.getProfilePhoto());
+
+        String newPhotoUrl = awss3Service.upload(updateRequestDTO.getProfilePhoto(), "profile-images");
+        user.changeProfilePhoto(newPhotoUrl);
 
         return userRepository.save(user).getId();
     }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #107

## 🏃‍ Task
- s3 세팅 📍 관련커밋: {9b43b27, 0981a13}
- s3 upload, delete 함수 구현 📍 관련커밋: {0a4ce8d, 818fa7c}
- 프로필 수정 시 S3를 이용하여 이미지 저장 📍 관련커밋: {59ed70b, 8849142}
- 프로필 사진 변경 시 이전에 S3를 통해 업로드된 사진이 있는 경우 삭제 📍 관련커밋: {818fa7c}

> <img width="1550" alt="image" src="https://github.com/TAVE-balak/OTTify-backend/assets/110277768/8a413195-7d97-4318-a936-98374eb89418">
> -> 해당 로직을 통해 유저 한명 당 하나의 프로필 사진만 s3에 저장됩니다.

## 기타 전달 사항
#### 1. postman을 통해 테스트 해봤을 땐 성공적으로 프로필 수정이 완료되었지만, swagger에서는 테스트가 되지 않습니다. 

- postman 
<img width="998" alt="image" src="https://github.com/TAVE-balak/OTTify-backend/assets/110277768/9c6c4ac1-ac70-4df4-8304-5b09ef45ed17">

- swagger
<img width="664" alt="image" src="https://github.com/TAVE-balak/OTTify-backend/assets/110277768/210ac8b2-1d49-4bd7-bb71-da2f36ecba1c">

> 이는 swagger에서는 파라미터 별로 content-type을 지정할 수 없어서 발생한 문제입니다.
> (관련 자료: https://velog.io/@byulcode/SpringBoot-DTO-MultipartFile-동시-요청-오류) 
> 또한 자료에 나온 해결법대로 시도해 보았으나 @Schema 어노테이션은 swagger 라이브러리 Springfox Swagger와 SpringDoc 중 SpringDoc에서만 지원되는 어노테이션이라 해결하지 못했습니다.

#### 2. application.yml에 추가되는 내용이 있어서 `노션 > 백엔드 > 아카이브 > application.yml`에 업데이트 해놓고 secret에 반영하겠습니다.


## 📄 Reference
- https://github.com/dnd-side-project/dnd-9th-9-backend/blob/develop/src/main/java/com/dnd/Exercise/global/s3/AwsS3Service.java
- https://inpa.tistory.com/entry/JS-📚-Base64-Blob-ArrayBuffer-File-다루기-정말-이해하기-쉽게-설명#
- https://techblog.woowahan.com/11392/

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?