### PR TITLE
Feature/#110 discussion

### DIFF
--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -65,7 +65,7 @@ public class CommunityController {
         @Valid @RequestPart(value = "dto") CommunitySubjectEditDTO c,
         @RequestPart(value = "file", required = false) MultipartFile image)
         throws NotFoundException {
-        communityService.modifySubject(c);
+        communityService.modifySubject(c, image);
         return BaseResponse.success("성공적으로 토론주제를 수정하였습니다.");
     }
 

--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -14,18 +14,17 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 import tavebalak.OTTify.common.BaseResponse;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageEditDTO;
 import tavebalak.OTTify.community.dto.request.ReplyCommentCreateDTO;
 import tavebalak.OTTify.community.dto.request.ReplyCommentEditDTO;
 import tavebalak.OTTify.community.dto.request.ReplyRecommentCreateDTO;
@@ -48,13 +47,11 @@ public class CommunityController {
 
     @ApiOperation(value = "토론주제 생성", notes = "회원이 작성한 토론내용을 기반으로 생성됩니다.")
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 생성하였습니다.")
-    @PostMapping(value = "/subject", consumes = {MediaType.APPLICATION_JSON_VALUE,
-        MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/subject", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<String> registerSubject(
-        @Valid @RequestPart(value = "dto") CommunitySubjectCreateDTO c,
-        @RequestPart(value = "file", required = false) MultipartFile image)
+        @Valid @ModelAttribute CommunitySubjectImageCreateDTO c)
         throws IOException {
-        communityService.saveSubject(c, image);
+        communityService.saveSubject(c);
         return BaseResponse.success("성공적으로 토론주제를 생성하였습니다.");
     }
 
@@ -62,10 +59,9 @@ public class CommunityController {
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 수정하였습니다.")
     @PutMapping("/subject")
     public BaseResponse<String> modifySubject(
-        @Valid @RequestPart(value = "dto") CommunitySubjectEditDTO c,
-        @RequestPart(value = "file", required = false) MultipartFile image)
+        @Valid @ModelAttribute CommunitySubjectImageEditDTO c)
         throws NotFoundException {
-        communityService.modifySubject(c, image);
+        communityService.modifySubject(c);
         return BaseResponse.success("성공적으로 토론주제를 수정하였습니다.");
     }
 

--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -14,17 +14,18 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import tavebalak.OTTify.common.BaseResponse;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
 import tavebalak.OTTify.community.dto.request.ReplyCommentCreateDTO;
 import tavebalak.OTTify.community.dto.request.ReplyCommentEditDTO;
 import tavebalak.OTTify.community.dto.request.ReplyRecommentCreateDTO;
@@ -47,17 +48,22 @@ public class CommunityController {
 
     @ApiOperation(value = "토론주제 생성", notes = "회원이 작성한 토론내용을 기반으로 생성됩니다.")
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 생성하였습니다.")
-    @PostMapping(value = "/subject", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/subject", consumes = {MediaType.APPLICATION_JSON_VALUE,
+        MediaType.MULTIPART_FORM_DATA_VALUE})
     public BaseResponse<String> registerSubject(
-        @Valid @ModelAttribute CommunitySubjectImageCreateDTO c) throws IOException {
-        communityService.saveSubject(c);
+        @Valid @RequestPart(value = "dto") CommunitySubjectCreateDTO c,
+        @RequestPart(value = "file", required = false) MultipartFile image)
+        throws IOException {
+        communityService.saveSubject(c, image);
         return BaseResponse.success("성공적으로 토론주제를 생성하였습니다.");
     }
 
     @ApiOperation(value = "토론주제 수정", notes = "회원이 작성한 토론내용을 기반으로 수정됩니다.")
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 수정하였습니다.")
     @PutMapping("/subject")
-    public BaseResponse<String> modifySubject(@Valid @ModelAttribute CommunitySubjectEditDTO c)
+    public BaseResponse<String> modifySubject(
+        @Valid @RequestPart(value = "dto") CommunitySubjectEditDTO c,
+        @RequestPart(value = "file", required = false) MultipartFile image)
         throws NotFoundException {
         communityService.modifySubject(c);
         return BaseResponse.success("성공적으로 토론주제를 수정하였습니다.");

--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -11,8 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -45,9 +47,9 @@ public class CommunityController {
 
     @ApiOperation(value = "토론주제 생성", notes = "회원이 작성한 토론내용을 기반으로 생성됩니다.")
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 생성하였습니다.")
-    @PostMapping(value = "/subject")
+    @PostMapping(value = "/subject", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<String> registerSubject(
-        @Valid @RequestBody CommunitySubjectCreateDTO c) throws IOException {
+        @Valid @ModelAttribute CommunitySubjectCreateDTO c) throws IOException {
         communityService.saveSubject(c);
         return BaseResponse.success("성공적으로 토론주제를 생성하였습니다.");
     }
@@ -55,7 +57,7 @@ public class CommunityController {
     @ApiOperation(value = "토론주제 수정", notes = "회원이 작성한 토론내용을 기반으로 수정됩니다.")
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 수정하였습니다.")
     @PutMapping("/subject")
-    public BaseResponse<String> modifySubject(@Valid @RequestBody CommunitySubjectEditDTO c)
+    public BaseResponse<String> modifySubject(@Valid @ModelAttribute CommunitySubjectEditDTO c)
         throws NotFoundException {
         communityService.modifySubject(c);
         return BaseResponse.success("성공적으로 토론주제를 수정하였습니다.");

--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
-import java.io.IOException;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -49,8 +48,7 @@ public class CommunityController {
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 생성하였습니다.")
     @PostMapping(value = "/subject", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<String> registerSubject(
-        @Valid @ModelAttribute CommunitySubjectImageCreateDTO c)
-        throws IOException {
+        @Valid @ModelAttribute CommunitySubjectImageCreateDTO c) {
         communityService.saveSubject(c);
         return BaseResponse.success("성공적으로 토론주제를 생성하였습니다.");
     }

--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -29,7 +29,7 @@ import tavebalak.OTTify.community.dto.request.ReplyCommentEditDTO;
 import tavebalak.OTTify.community.dto.request.ReplyRecommentCreateDTO;
 import tavebalak.OTTify.community.dto.request.ReplyRecommentEditDTO;
 import tavebalak.OTTify.community.dto.response.CommunityAriclesDTO;
-import tavebalak.OTTify.community.dto.response.CommunitySubjectsDTO;
+import tavebalak.OTTify.community.dto.response.CommunitySubjectsListDTO;
 import tavebalak.OTTify.community.service.CommunityService;
 import tavebalak.OTTify.community.service.ReplyService;
 import tavebalak.OTTify.error.exception.NotFoundException;
@@ -110,13 +110,13 @@ public class CommunityController {
         @ApiImplicitParam(name = "size", value = "페이지당 아이템 갯수", paramType = "query")
     })
     @GetMapping("/total")
-    public BaseResponse<CommunitySubjectsDTO> getTotalProgramsSubjects(
+    public BaseResponse<CommunitySubjectsListDTO> getTotalProgramsSubjects(
         @PageableDefault(size = 10,
             sort = "createdAt",
             direction = Sort.Direction.DESC,
             page = 0
         ) Pageable pageable) {
-        CommunitySubjectsDTO page = communityService.findAllSubjects(pageable);
+        CommunitySubjectsListDTO page = communityService.findAllSubjects(pageable);
         return BaseResponse.success(page);
     }
 
@@ -129,14 +129,15 @@ public class CommunityController {
         @ApiImplicitParam(name = "programId", value = "프로그램 id", required = true, paramType = "query")
     })
     @GetMapping("/program")
-    public BaseResponse<CommunitySubjectsDTO> getTotalProgramSubjects(
+    public BaseResponse<CommunitySubjectsListDTO> getTotalProgramSubjects(
         @PageableDefault(size = 10,
             sort = "createdAt",
             direction = Sort.Direction.DESC,
             page = 0) Pageable pageable,
         @RequestParam("programId") Long programId) {
 
-        CommunitySubjectsDTO page = communityService.findSingleProgramSubjects(pageable, programId);
+        CommunitySubjectsListDTO page = communityService.findSingleProgramSubjects(pageable,
+            programId);
         return BaseResponse.success(page);
     }
 

--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -23,8 +23,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tavebalak.OTTify.common.BaseResponse;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
 import tavebalak.OTTify.community.dto.request.ReplyCommentCreateDTO;
 import tavebalak.OTTify.community.dto.request.ReplyCommentEditDTO;
 import tavebalak.OTTify.community.dto.request.ReplyRecommentCreateDTO;
@@ -49,7 +49,7 @@ public class CommunityController {
     @ApiResponse(code = 200, message = "성공적으로 토론주제를 생성하였습니다.")
     @PostMapping(value = "/subject", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<String> registerSubject(
-        @Valid @ModelAttribute CommunitySubjectCreateDTO c) throws IOException {
+        @Valid @ModelAttribute CommunitySubjectImageCreateDTO c) throws IOException {
         communityService.saveSubject(c);
         return BaseResponse.success("성공적으로 토론주제를 생성하였습니다.");
     }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectCreateDTO.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Getter
@@ -21,11 +22,16 @@ public class CommunitySubjectCreateDTO {
     @NotBlank
     @ApiParam(value = "토론 내용", required = true)
     private String content;
+    @ApiParam(value = "이미지", required = false)
+    private MultipartFile image;
 
     @Builder
-    public CommunitySubjectCreateDTO(Long programId, String subjectName, String content) {
+    public CommunitySubjectCreateDTO(Long programId, String subjectName, String content,
+        MultipartFile image
+    ) {
         this.programId = programId;
         this.subjectName = subjectName;
         this.content = content;
+        this.image = image;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectCreateDTO.java
@@ -1,6 +1,5 @@
 package tavebalak.OTTify.community.dto.request;
 
-import io.swagger.annotations.ApiParam;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -13,13 +12,10 @@ import lombok.NoArgsConstructor;
 public class CommunitySubjectCreateDTO {
 
     @NotNull
-    @ApiParam(value = "프로그램 id", required = true)
     private Long programId;
     @NotBlank
-    @ApiParam(value = "토론 제목", required = true)
     private String subjectName;
     @NotBlank
-    @ApiParam(value = "토론 내용", required = true)
     private String content;
 
     @Builder

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
@@ -5,9 +5,7 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
@@ -23,14 +21,5 @@ public class CommunitySubjectEditDTO {
     @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
     @ApiModelProperty(value = "토론 내용")
     private String content;
-    @ApiModelProperty(value = "이미지 파일을 수정")
-    private MultipartFile image;
-
-    @Builder
-    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content) {
-        this.subjectId = subjectId;
-        this.subjectName = subjectName;
-        this.content = content;
-    }
 
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
@@ -1,7 +1,5 @@
 package tavebalak.OTTify.community.dto.request;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -10,17 +8,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@ApiModel(value = "CommunitySubjectEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용을 가진 Domain Class")
 public class CommunitySubjectEditDTO {
 
     @NotNull
-    @ApiModelProperty(value = "토론 주제 id")
     private Long subjectId;
     @NotBlank(message = "토론 주제 제목이 비워져 있어서는 안됩니다.")
-    @ApiModelProperty(value = "토론 주제")
     private String subjectName;
     @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
-    @ApiModelProperty(value = "토론 내용")
     private String content;
 
     @Builder

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @NoArgsConstructor
@@ -22,6 +23,8 @@ public class CommunitySubjectEditDTO {
     @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
     @ApiModelProperty(value = "토론 내용")
     private String content;
+    @ApiModelProperty(value = "이미지 파일을 수정")
+    private MultipartFile image;
 
     @Builder
     public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content) {
@@ -29,4 +32,14 @@ public class CommunitySubjectEditDTO {
         this.subjectName = subjectName;
         this.content = content;
     }
+
+    @Builder(builderMethodName = "imageIncludeBuilder")
+    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content,
+        MultipartFile image) {
+        this.subjectId = subjectId;
+        this.subjectName = subjectName;
+        this.content = content;
+        this.image = image;
+    }
+
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
@@ -4,13 +4,13 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 @ApiModel(value = "CommunitySubjectEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용을 가진 Domain Class")
 public class CommunitySubjectEditDTO {
 
@@ -31,15 +31,6 @@ public class CommunitySubjectEditDTO {
         this.subjectId = subjectId;
         this.subjectName = subjectName;
         this.content = content;
-    }
-
-    @Builder(builderMethodName = "imageIncludeBuilder")
-    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content,
-        MultipartFile image) {
-        this.subjectId = subjectId;
-        this.subjectName = subjectName;
-        this.content = content;
-        this.image = image;
     }
 
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
@@ -21,7 +21,7 @@ public class CommunitySubjectImageCreateDTO {
     @NotBlank
     @ApiParam(value = "토론 내용", required = true)
     private String content;
-    @ApiParam(value = "이미지", required = false)
+    @ApiParam(value = "이미지", required = true)
     private MultipartFile image;
 
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
@@ -1,5 +1,6 @@
 package tavebalak.OTTify.community.dto.request;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiParam;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -10,18 +11,22 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
+@ApiModel(value = "CommunitySubjectImageCreateDTO(토론주제 생성 정보)", description = "토론주제 id, 토론제목, 토론내용, 이미지 파일 내용을 가진 Domain Class")
 public class CommunitySubjectImageCreateDTO {
 
     @NotNull
     @ApiParam(value = "프로그램 id", required = true)
     private Long programId;
-    @NotBlank
+
+    @NotBlank(message = "토론 주제 제목이 비워져 있어서는 안됩니다.")
     @ApiParam(value = "토론 제목", required = true)
     private String subjectName;
-    @NotBlank
+
+    @NotBlank(message = "토론 내용이 비워져 있어서는 안됩니다.")
     @ApiParam(value = "토론 내용", required = true)
     private String content;
-    @ApiParam(value = "이미지", required = true)
+    
+    @ApiParam(value = "이미지")
     private MultipartFile image;
 
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
@@ -1,7 +1,7 @@
 package tavebalak.OTTify.community.dto.request;
 
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -15,18 +15,18 @@ import org.springframework.web.multipart.MultipartFile;
 public class CommunitySubjectImageCreateDTO {
 
     @NotNull
-    @ApiParam(value = "프로그램 id", required = true)
+    @ApiModelProperty(value = "프로그램 id", required = true)
     private Long programId;
 
     @NotBlank(message = "토론 주제 제목이 비워져 있어서는 안됩니다.")
-    @ApiParam(value = "토론 제목", required = true)
+    @ApiModelProperty(value = "토론 제목", required = true)
     private String subjectName;
 
     @NotBlank(message = "토론 내용이 비워져 있어서는 안됩니다.")
-    @ApiParam(value = "토론 내용", required = true)
+    @ApiModelProperty(value = "토론 내용", required = true)
     private String content;
-    
-    @ApiParam(value = "이미지")
+
+    @ApiModelProperty(value = "이미지")
     private MultipartFile image;
 
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageCreateDTO.java
@@ -3,14 +3,14 @@ package tavebalak.OTTify.community.dto.request;
 import io.swagger.annotations.ApiParam;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Getter
-@NoArgsConstructor
-public class CommunitySubjectCreateDTO {
+@AllArgsConstructor
+public class CommunitySubjectImageCreateDTO {
 
     @NotNull
     @ApiParam(value = "프로그램 id", required = true)
@@ -21,12 +21,7 @@ public class CommunitySubjectCreateDTO {
     @NotBlank
     @ApiParam(value = "토론 내용", required = true)
     private String content;
+    @ApiParam(value = "이미지", required = false)
+    private MultipartFile image;
 
-    @Builder
-    public CommunitySubjectCreateDTO(Long programId, String subjectName, String content
-    ) {
-        this.programId = programId;
-        this.subjectName = subjectName;
-        this.content = content;
-    }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageEditDTO.java
@@ -2,16 +2,17 @@ package tavebalak.OTTify.community.dto.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.ApiParam;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@NoArgsConstructor
-@ApiModel(value = "CommunitySubjectEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용을 가진 Domain Class")
-public class CommunitySubjectEditDTO {
+@AllArgsConstructor
+@ApiModel(value = "CommunitySubjectImageEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용을 가진 Domain Class")
+public class CommunitySubjectImageEditDTO {
 
     @NotNull
     @ApiModelProperty(value = "토론 주제 id")
@@ -22,12 +23,6 @@ public class CommunitySubjectEditDTO {
     @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
     @ApiModelProperty(value = "토론 내용")
     private String content;
-
-    @Builder
-    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content) {
-        this.content = content;
-        this.subjectName = subjectName;
-        this.subjectId = subjectId;
-    }
-
+    @ApiParam(value = "이미지", required = false)
+    private MultipartFile image;
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectImageEditDTO.java
@@ -11,18 +11,21 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
-@ApiModel(value = "CommunitySubjectImageEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용을 가진 Domain Class")
+@ApiModel(value = "CommunitySubjectImageEditDTO(토론주제 수정 정보)", description = "토론주제 id, 토론제목, 토론내용, 이미지 파일 내용을 가진 Domain Class")
 public class CommunitySubjectImageEditDTO {
 
     @NotNull
-    @ApiModelProperty(value = "토론 주제 id")
+    @ApiModelProperty(value = "토론 주제 id", required = true)
     private Long subjectId;
+
     @NotBlank(message = "토론 주제 제목이 비워져 있어서는 안됩니다.")
-    @ApiModelProperty(value = "토론 주제")
+    @ApiModelProperty(value = "토론 주제", required = true)
     private String subjectName;
-    @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
-    @ApiModelProperty(value = "토론 내용")
+
+    @NotBlank(message = "토론 내용이 비워져 있어서는 안됩니다.")
+    @ApiModelProperty(value = "토론 내용", required = true)
     private String content;
-    @ApiParam(value = "이미지", required = false)
+
+    @ApiParam(value = "이미지")
     private MultipartFile image;
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/ReplyCommentCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/ReplyCommentCreateDTO.java
@@ -15,10 +15,10 @@ import lombok.NoArgsConstructor;
 public class ReplyCommentCreateDTO {
 
     @NotNull
-    @ApiModelProperty(value = "토론 주제 id")
+    @ApiModelProperty(value = "토론 주제 id", required = true)
     private Long subjectId;
     @NotBlank(message = "댓글 내용은 비어있어서는 안됩니다.")
-    @ApiModelProperty(value = "댓글 내용")
+    @ApiModelProperty(value = "댓글 내용", required = true)
     private String comment;
 
     @Builder

--- a/src/main/java/tavebalak/OTTify/community/dto/request/ReplyCommentEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/ReplyCommentEditDTO.java
@@ -13,13 +13,13 @@ import lombok.NoArgsConstructor;
 public class ReplyCommentEditDTO {
 
     @NotNull
-    @ApiModelProperty(value = "토론 주제 id")
+    @ApiModelProperty(value = "토론 주제 id", required = true)
     private Long subjectId;
     @NotNull
-    @ApiModelProperty(value = "댓글 id")
+    @ApiModelProperty(value = "댓글 id", required = true)
     private Long commentId;
     @NotBlank(message = "댓글 내용이 비워져 있어서는 안됩니다.")
-    @ApiModelProperty(value = "댓글 내용")
+    @ApiModelProperty(value = "댓글 내용", required = true)
     private String comment;
 
     public ReplyCommentEditDTO(Long subjectId, Long commentId, String comment) {

--- a/src/main/java/tavebalak/OTTify/community/dto/request/ReplyRecommentCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/ReplyRecommentCreateDTO.java
@@ -1,7 +1,7 @@
 package tavebalak.OTTify.community.dto.request;
 
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -14,13 +14,13 @@ import lombok.NoArgsConstructor;
 public class ReplyRecommentCreateDTO {
 
     @NotNull
-    @ApiParam(name = "토론 주제 id", required = true)
+    @ApiModelProperty(name = "토론 주제 id", required = true)
     private Long subjectId;
     @NotNull
-    @ApiParam(name = "토론 대댓글 id", required = true)
+    @ApiModelProperty(name = "토론 대댓글 id", required = true)
     private Long commentId;
     @NotBlank(message = "대댓글 내용이 비워져 있어서는 안됩니다.")
-    @ApiParam(name = "토론 대댓글 내용", required = true)
+    @ApiModelProperty(name = "토론 대댓글 내용", required = true)
     private String content;
 
     @Builder

--- a/src/main/java/tavebalak/OTTify/community/dto/request/ReplyRecommentCreateDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/ReplyRecommentCreateDTO.java
@@ -1,5 +1,6 @@
 package tavebalak.OTTify.community.dto.request;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiParam;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@ApiModel(value = "ReplyRecommentCreateDTO(대댓글 생성 정보)", description = "토론주제 id, 토론 대댓글 id, 토론 대댓글 내용을 가진 Domain Class")
 public class ReplyRecommentCreateDTO {
 
     @NotNull

--- a/src/main/java/tavebalak/OTTify/community/dto/request/ReplyRecommentEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/ReplyRecommentEditDTO.java
@@ -14,16 +14,19 @@ import lombok.NoArgsConstructor;
 public class ReplyRecommentEditDTO {
 
     @NotNull
-    @ApiModelProperty(value = "토론 주제 id")
+    @ApiModelProperty(value = "토론 주제 id", required = true)
     private Long subjectId;
+
     @NotNull
-    @ApiModelProperty(value = "토론 댓글 id")
+    @ApiModelProperty(value = "토론 댓글 id", required = true)
     private Long commentId;
+
     @NotNull
-    @ApiModelProperty(value = "토론 대댓글 id")
+    @ApiModelProperty(value = "토론 대댓글 id", required = true)
     private Long recommentId;
+
     @NotBlank(message = "대댓글 수정시 내용이 비워져있으면 안됩니다.")
-    @ApiModelProperty(value = "토론 대댓글 내용")
+    @ApiModelProperty(value = "토론 대댓글 내용", required = true)
     private String content;
 
     @Builder

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunityAriclesDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunityAriclesDTO.java
@@ -10,7 +10,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@ApiModel(value = "CommunityAriclesDTO(토론 주제글 조회)", description = "토론 주제, 글쓴이, 글쓴이 id, 내용, 작성일, 수정일, 댓글 수, 공감 수, 토론 주제 id, 댓글 리스트 내용을 가진 Domain Class")
+@ApiModel(value = "CommunityAriclesDTO(토론 주제글 조회)",
+    description = "토론 주제, 글쓴이, 글쓴이 id, 내용, 작성일, 수정일, 댓글 수, 공감 수, 토론 주제 id, 댓글 리스트, 이미지 url 내용을 가진 Domain Class")
 public class CommunityAriclesDTO {
 
     @ApiModelProperty(value = "토론 주제")
@@ -35,6 +36,8 @@ public class CommunityAriclesDTO {
     private String programTitle;
     @ApiModelProperty(value = "댓글 리스트")
     private List<CommentListsDTO> commentListsDTOList;
+    @ApiModelProperty(value = "이미지 url")
+    private String imageUrl;
 
     @Builder
     public CommunityAriclesDTO(String title,
@@ -47,7 +50,8 @@ public class CommunityAriclesDTO {
         List<CommentListsDTO> commentListsDTOList,
         int likeCount,
         Long subjectId,
-        String programTitle
+        String programTitle,
+        String imageUrl
     ) {
         this.title = title;
         this.writer = writer;
@@ -60,5 +64,6 @@ public class CommunityAriclesDTO {
         this.likeCount = likeCount;
         this.subjectId = subjectId;
         this.programTitle = programTitle;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectEditorDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectEditorDTO.java
@@ -15,6 +15,7 @@ public class CommunitySubjectEditorDTO {
         this.content = content;
     }
 
+
     public CommunitySubjectEditorDTO changeTitleContentProgram(String subjectName, String content) {
         this.title = subjectName;
         this.content = content;

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectImageEditorDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectImageEditorDTO.java
@@ -18,7 +18,7 @@ public class CommunitySubjectImageEditorDTO {
     }
 
 
-    public CommunitySubjectImageEditorDTO changeTitleContentProgramImage(String subjectName,
+    public CommunitySubjectImageEditorDTO changeTitleContentImage(String subjectName,
         String content, String imageUrl) {
         this.title = subjectName;
         this.content = content;

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectImageEditorDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectImageEditorDTO.java
@@ -1,0 +1,29 @@
+package tavebalak.OTTify.community.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommunitySubjectImageEditorDTO {
+
+    private String title;
+    private String content;
+    private String imageUrl;
+
+    public CommunitySubjectImageEditorDTO(String title, String content, String imageUrl) {
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+    }
+
+
+    public CommunitySubjectImageEditorDTO changeTitleContentProgramImage(String subjectName,
+        String content, String imageUrl) {
+        this.title = subjectName;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        return this;
+    }
+
+}

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsDTO.java
@@ -16,10 +16,14 @@ public class CommunitySubjectsDTO {
     private int subjectAmount;
     @ApiModelProperty(value = "토론 주제 리스트")
     private List<CommunitySubjectsListDTO> list;
+    @ApiModelProperty(value = "다음 페이지 여부")
+    private boolean hasNext;
 
     @Builder
-    public CommunitySubjectsDTO(int subjectAmount, List<CommunitySubjectsListDTO> list) {
+    public CommunitySubjectsDTO(int subjectAmount, List<CommunitySubjectsListDTO> list,
+        boolean hasNext) {
         this.subjectAmount = subjectAmount;
         this.list = list;
+        this.hasNext = hasNext;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsDTO.java
@@ -2,28 +2,52 @@ package tavebalak.OTTify.community.dto.response;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.List;
+import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@ApiModel(value = "CommunitySubjectsDTO(프로그램별 토론 주제 조회 정보)", description = "총 갯수, 토론 주제 내용을 가진 Domain Class")
+@EqualsAndHashCode
+@ApiModel(value = "CommunitySubjectsDTO(토론주제글 구성 정보)", description = "생성일, 수정일, 토론주제, 글쓴이, 프로그램 id, 토론주제 id, 공감 수, 이미지 url 내용을 가진 Domain Class")
 public class CommunitySubjectsDTO {
 
-    @ApiModelProperty(value = "총 토론주제 갯수")
-    private int subjectAmount;
-    @ApiModelProperty(value = "토론 주제 리스트")
-    private List<CommunitySubjectsListDTO> list;
-    @ApiModelProperty(value = "다음 페이지 여부")
-    private boolean hasNext;
+    @ApiModelProperty(value = "글 생성일")
+    private LocalDateTime createdAt;
+    @ApiModelProperty(value = "글 수정일")
+    private LocalDateTime updatedAt;
+    @ApiModelProperty(value = "토론주제 제목")
+    private String title;
+    @ApiModelProperty(value = "글쓴이")
+    private String nickName;
+    @ApiModelProperty(value = "프로그램 id")
+    private Long programId;
+    @ApiModelProperty(value = "토론주제 id")
+    private Long subjectId;
+    @ApiModelProperty(value = "공감 수")
+    private int likeCount;
+    @ApiModelProperty(value = "이미지 url")
+    private String imageUrl;
 
     @Builder
-    public CommunitySubjectsDTO(int subjectAmount, List<CommunitySubjectsListDTO> list,
-        boolean hasNext) {
-        this.subjectAmount = subjectAmount;
-        this.list = list;
-        this.hasNext = hasNext;
+    public CommunitySubjectsDTO(LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        String title,
+        String nickName,
+        Long programId,
+        Long subjectId,
+        int likeCount,
+        String imageUrl
+    ) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.title = title;
+        this.nickName = nickName;
+        this.programId = programId;
+        this.subjectId = subjectId;
+        this.likeCount = likeCount;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsListDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsListDTO.java
@@ -2,52 +2,28 @@ package tavebalak.OTTify.community.dto.response;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@EqualsAndHashCode
-@ApiModel(value = "CommunitySubjectsListDTO(토론주제글 구성 정보)", description = "생성일, 수정일, 토론주제, 글쓴이, 프로그램 id, 토론주제 id, 공감 수, 이미지 url 내용을 가진 Domain Class")
+@ApiModel(value = "CommunitySubjectsListDTO(프로그램별 토론 주제 조회 정보)", description = "총 갯수, 토론 주제 내용을 가진 Domain Class")
 public class CommunitySubjectsListDTO {
 
-    @ApiModelProperty(value = "글 생성일")
-    private LocalDateTime createdAt;
-    @ApiModelProperty(value = "글 수정일")
-    private LocalDateTime updatedAt;
-    @ApiModelProperty(value = "토론주제 제목")
-    private String title;
-    @ApiModelProperty(value = "글쓴이")
-    private String nickName;
-    @ApiModelProperty(value = "프로그램 id")
-    private Long programId;
-    @ApiModelProperty(value = "토론주제 id")
-    private Long subjectId;
-    @ApiModelProperty(value = "공감 수")
-    private int likeCount;
-    @ApiModelProperty(value = "이미지 url")
-    private String imageUrl;
+    @ApiModelProperty(value = "총 토론주제 갯수")
+    private int subjectAmount;
+    @ApiModelProperty(value = "토론 주제 리스트")
+    private List<CommunitySubjectsDTO> list;
+    @ApiModelProperty(value = "다음 페이지 여부")
+    private boolean hasNext;
 
     @Builder
-    public CommunitySubjectsListDTO(LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        String title,
-        String nickName,
-        Long programId,
-        Long subjectId,
-        int likeCount,
-        String imageUrl
-    ) {
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.title = title;
-        this.nickName = nickName;
-        this.programId = programId;
-        this.subjectId = subjectId;
-        this.likeCount = likeCount;
-        this.imageUrl = imageUrl;
+    public CommunitySubjectsListDTO(int subjectAmount, List<CommunitySubjectsDTO> list,
+        boolean hasNext) {
+        this.subjectAmount = subjectAmount;
+        this.list = list;
+        this.hasNext = hasNext;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsListDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/response/CommunitySubjectsListDTO.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @EqualsAndHashCode
-@ApiModel(value = "CommunitySubjectsListDTO(토론주제글 구성 정보)", description = "생성일, 수정일, 토론주제, 글쓴이, 프로그램 id, 토론주제 id, 공감 수 내용을 가진 Domain Class")
+@ApiModel(value = "CommunitySubjectsListDTO(토론주제글 구성 정보)", description = "생성일, 수정일, 토론주제, 글쓴이, 프로그램 id, 토론주제 id, 공감 수, 이미지 url 내용을 가진 Domain Class")
 public class CommunitySubjectsListDTO {
 
     @ApiModelProperty(value = "글 생성일")
@@ -28,6 +28,8 @@ public class CommunitySubjectsListDTO {
     private Long subjectId;
     @ApiModelProperty(value = "공감 수")
     private int likeCount;
+    @ApiModelProperty(value = "이미지 url")
+    private String imageUrl;
 
     @Builder
     public CommunitySubjectsListDTO(LocalDateTime createdAt,
@@ -36,7 +38,8 @@ public class CommunitySubjectsListDTO {
         String nickName,
         Long programId,
         Long subjectId,
-        int likeCount
+        int likeCount,
+        String imageUrl
     ) {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -45,5 +48,6 @@ public class CommunitySubjectsListDTO {
         this.programId = programId;
         this.subjectId = subjectId;
         this.likeCount = likeCount;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/entity/Community.java
+++ b/src/main/java/tavebalak/OTTify/community/entity/Community.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import tavebalak.OTTify.common.entity.BaseEntity;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectEditorDTO;
+import tavebalak.OTTify.community.dto.response.CommunitySubjectImageEditorDTO;
 import tavebalak.OTTify.program.entity.Program;
 import tavebalak.OTTify.user.entity.User;
 
@@ -48,21 +49,33 @@ public class Community extends BaseEntity {
     private String imageUrl;
 
     @Builder
-    public Community(Long id, String title, String content, Program program, User user) {
+    public Community(Long id, String title, String content, Program program, User user,
+        String imageUrl) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.program = program;
         this.user = user;
+        this.imageUrl = imageUrl;
     }
 
     public CommunitySubjectEditorDTO toEditor() {
         return new CommunitySubjectEditorDTO(title, content);
     }
 
+    public CommunitySubjectImageEditorDTO toImageEdior() {
+        return new CommunitySubjectImageEditorDTO(title, content, imageUrl);
+    }
+
     public void edit(CommunitySubjectEditorDTO communitySubjectEditorDTO) {
         this.title = communitySubjectEditorDTO.getTitle();
         this.content = communitySubjectEditorDTO.getContent();
+    }
+
+    public void editImage(CommunitySubjectImageEditorDTO communitySubjectImageEditorDTO) {
+        this.title = communitySubjectImageEditorDTO.getTitle();
+        this.content = communitySubjectImageEditorDTO.getContent();
+        this.imageUrl = communitySubjectImageEditorDTO.getImageUrl();
     }
 
     public void setUser(User user) {

--- a/src/main/java/tavebalak/OTTify/community/repository/CommunityRepository.java
+++ b/src/main/java/tavebalak/OTTify/community/repository/CommunityRepository.java
@@ -1,15 +1,15 @@
 package tavebalak.OTTify.community.repository;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tavebalak.OTTify.community.entity.Community;
 
-import java.util.List;
-
 public interface CommunityRepository extends JpaRepository<Community, Long> {
-    Page<Community> findCommunitiesBy(Pageable pageable);
-    Page<Community> findCommunitiesByProgramId(Pageable pageable, Long programId);
+
+    Slice<Community> findCommunitiesBy(Pageable pageable);
+
+    Slice<Community> findCommunitiesByProgramId(Pageable pageable, Long programId);
+
     Slice<Community> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
@@ -1,8 +1,8 @@
 package tavebalak.OTTify.community.service;
 
 import org.springframework.data.domain.Pageable;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
 import tavebalak.OTTify.community.dto.response.CommunityAriclesDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectsDTO;
@@ -10,7 +10,7 @@ import tavebalak.OTTify.community.entity.Community;
 
 public interface CommunityService {
 
-    Community saveSubject(CommunitySubjectCreateDTO c);
+    Community saveSubject(CommunitySubjectImageCreateDTO c);
 
     void modifySubject(CommunitySubjectEditDTO c);
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
@@ -1,9 +1,8 @@
 package tavebalak.OTTify.community.service;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.multipart.MultipartFile;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageEditDTO;
 import tavebalak.OTTify.community.dto.response.CommunityAriclesDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectsDTO;
@@ -11,9 +10,9 @@ import tavebalak.OTTify.community.entity.Community;
 
 public interface CommunityService {
 
-    Community saveSubject(CommunitySubjectCreateDTO c, MultipartFile image);
+    Community saveSubject(CommunitySubjectImageCreateDTO c);
 
-    void modifySubject(CommunitySubjectEditDTO c, MultipartFile image);
+    void modifySubject(CommunitySubjectImageEditDTO c);
 
     void deleteSubject(Long subjectId);
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
@@ -13,7 +13,7 @@ public interface CommunityService {
 
     Community saveSubject(CommunitySubjectCreateDTO c, MultipartFile image);
 
-    void modifySubject(CommunitySubjectEditDTO c);
+    void modifySubject(CommunitySubjectEditDTO c, MultipartFile image);
 
     void deleteSubject(Long subjectId);
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
@@ -5,7 +5,7 @@ import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectImageEditDTO;
 import tavebalak.OTTify.community.dto.response.CommunityAriclesDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectDTO;
-import tavebalak.OTTify.community.dto.response.CommunitySubjectsDTO;
+import tavebalak.OTTify.community.dto.response.CommunitySubjectsListDTO;
 import tavebalak.OTTify.community.entity.Community;
 
 public interface CommunityService {
@@ -16,13 +16,13 @@ public interface CommunityService {
 
     void deleteSubject(Long subjectId);
 
-    CommunitySubjectsDTO findAllSubjects(Pageable pageable);
+    CommunitySubjectsListDTO findAllSubjects(Pageable pageable);
 
     CommunityAriclesDTO getArticleOfASubject(Long subjectId);
 
     CommunitySubjectDTO getSubject(Long subjectId);
 
-    CommunitySubjectsDTO findSingleProgramSubjects(Pageable pageable, Long programId);
+    CommunitySubjectsListDTO findSingleProgramSubjects(Pageable pageable, Long programId);
 
     boolean likeSubject(Long subjectId);
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityService.java
@@ -1,8 +1,9 @@
 package tavebalak.OTTify.community.service;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
-import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
 import tavebalak.OTTify.community.dto.response.CommunityAriclesDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectsDTO;
@@ -10,7 +11,7 @@ import tavebalak.OTTify.community.entity.Community;
 
 public interface CommunityService {
 
-    Community saveSubject(CommunitySubjectImageCreateDTO c);
+    Community saveSubject(CommunitySubjectCreateDTO c, MultipartFile image);
 
     void modifySubject(CommunitySubjectEditDTO c);
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -162,6 +162,9 @@ public class CommunityServiceImpl implements CommunityService {
             throw new ForbiddenException(ErrorCode.CAN_NOT_DELETE_OTHER_SUBJECT_REQUEST);
         }
         communityRepository.delete(community);
+        if (community.getImageUrl() != null) {
+            awss3Service.delete(community.getImageUrl());
+        }
     }
 
     public void delete(Long subjectId, User user) {

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -61,6 +61,7 @@ public class CommunityServiceImpl implements CommunityService {
     public Community saveSubject(CommunitySubjectImageCreateDTO c) {
 
         String imageUrl = null;
+        System.out.println(c.getImage());
         if (!c.getImage().isEmpty()) {
             imageUrl = awss3Service.upload(c.getImage(), "discussion-image");
         }
@@ -189,6 +190,7 @@ public class CommunityServiceImpl implements CommunityService {
                 .programId(community.getProgram().getId())
                 .subjectId(community.getId())
                 .likeCount(getLikeSum(community.getId()))
+                .imageUrl(community.getImageUrl())
                 .build()
         ).collect(Collectors.toList());
         return CommunitySubjectsDTO.builder().subjectAmount((int) communities.getTotalElements())
@@ -208,6 +210,7 @@ public class CommunityServiceImpl implements CommunityService {
                 .nickName(community.getUser().getNickName())
                 .subjectId(community.getId())
                 .programId(programId)
+                .imageUrl(community.getImageUrl())
                 .build()
         ).collect(Collectors.toList());
 
@@ -334,6 +337,7 @@ public class CommunityServiceImpl implements CommunityService {
             .likeCount(getLikeSum(community.getId()))
             .subjectId(community.getId())
             .programTitle(community.getProgram().getTitle())
+            .imageUrl(community.getImageUrl())
             .build();
     }
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -80,7 +80,7 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     public Community save(CommunitySubjectCreateDTO c) {
-        Program program = isPresentNI(c);
+        Program program = isPresentNotImage(c);
 
         Community community = Community.builder()
             .title(c.getSubjectName())
@@ -91,7 +91,7 @@ public class CommunityServiceImpl implements CommunityService {
         return communityRepository.save(community);
     }
 
-    private Program isPresentNI(CommunitySubjectCreateDTO c) {
+    private Program isPresentNotImage(CommunitySubjectCreateDTO c) {
         Optional<Program> optionalProgram = programRepository.findById(c.getProgramId());
         return optionalProgram.orElseThrow(
             () -> new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND));
@@ -120,14 +120,14 @@ public class CommunityServiceImpl implements CommunityService {
             if (community.getImageUrl() != null) {
                 awss3Service.delete(community.getImageUrl());
             }
-            imageUrl = awss3Service.upload(c.getImage(), "discussion-image");
+            imageUrl = awss3Service.upload(c.getImage(), "discussion-images");
         } else {
             if (community.getImageUrl() != null) {
                 awss3Service.delete(community.getImageUrl());
             }
         }
 
-        CommunitySubjectImageEditorDTO communitySubjectImageEditorDTO = communitySubjectEditorDTOBuilder.changeTitleContentProgramImage(
+        CommunitySubjectImageEditorDTO communitySubjectImageEditorDTO = communitySubjectEditorDTOBuilder.changeTitleContentImage(
             c.getSubjectName(), c.getContent(), imageUrl);
         community.editImage(communitySubjectImageEditorDTO);
     }
@@ -172,10 +172,10 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     @Override
-    public CommunitySubjectsDTO findAllSubjects(Pageable pageable) {
+    public CommunitySubjectsListDTO findAllSubjects(Pageable pageable) {
         Slice<Community> communities = communityRepository.findCommunitiesBy(pageable);
-        List<CommunitySubjectsListDTO> listDTO = communities.stream().map(
-            community -> CommunitySubjectsListDTO
+        List<CommunitySubjectsDTO> listDTO = communities.stream().map(
+            community -> CommunitySubjectsDTO
                 .builder()
                 .createdAt(community.getCreatedAt())
                 .updatedAt(community.getUpdatedAt())
@@ -187,16 +187,16 @@ public class CommunityServiceImpl implements CommunityService {
                 .imageUrl(community.getImageUrl())
                 .build()
         ).collect(Collectors.toList());
-        return CommunitySubjectsDTO.builder().subjectAmount(communities.getNumberOfElements())
+        return CommunitySubjectsListDTO.builder().subjectAmount(communities.getNumberOfElements())
             .list(listDTO).hasNext(communities.hasNext()).build();
     }
 
     @Override
-    public CommunitySubjectsDTO findSingleProgramSubjects(Pageable pageable, Long programId) {
+    public CommunitySubjectsListDTO findSingleProgramSubjects(Pageable pageable, Long programId) {
         Slice<Community> communities = communityRepository.findCommunitiesByProgramId(pageable,
             programId);
-        List<CommunitySubjectsListDTO> list = communities.stream().map(
-            community -> CommunitySubjectsListDTO
+        List<CommunitySubjectsDTO> list = communities.stream().map(
+            community -> CommunitySubjectsDTO
                 .builder()
                 .createdAt(community.getCreatedAt())
                 .updatedAt(community.getUpdatedAt())
@@ -208,7 +208,7 @@ public class CommunityServiceImpl implements CommunityService {
                 .build()
         ).collect(Collectors.toList());
 
-        return CommunitySubjectsDTO.builder().subjectAmount(communities.getNumberOfElements())
+        return CommunitySubjectsListDTO.builder().subjectAmount(communities.getNumberOfElements())
             .list(list).hasNext(communities.hasNext()).build();
     }
 

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -93,21 +93,15 @@ public class CommunityServiceImpl implements CommunityService {
 
     private Program isPresentNI(CommunitySubjectCreateDTO c) {
         Optional<Program> optionalProgram = programRepository.findById(c.getProgramId());
-        if (optionalProgram.isPresent()) {
-            return optionalProgram.get();
-        } else {
-            throw new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND);
-        }
+        return optionalProgram.orElseThrow(
+            () -> new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND));
     }
 
 
     private Program isPresent(CommunitySubjectImageCreateDTO c) {
         Optional<Program> optionalProgram = programRepository.findById(c.getProgramId());
-        if (optionalProgram.isPresent()) {
-            return optionalProgram.get();
-        } else {
-            throw new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND);
-        }
+        return optionalProgram.orElseThrow(
+            () -> new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -12,8 +12,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tavebalak.OTTify.common.s3.AWSS3Service;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectCreateDTO;
 import tavebalak.OTTify.community.dto.request.CommunitySubjectEditDTO;
+import tavebalak.OTTify.community.dto.request.CommunitySubjectImageCreateDTO;
 import tavebalak.OTTify.community.dto.response.CommentListsDTO;
 import tavebalak.OTTify.community.dto.response.CommunityAriclesDTO;
 import tavebalak.OTTify.community.dto.response.CommunitySubjectDTO;
@@ -55,7 +57,7 @@ public class CommunityServiceImpl implements CommunityService {
     private final AWSS3Service awss3Service;
 
     @Override
-    public Community saveSubject(CommunitySubjectCreateDTO c) {
+    public Community saveSubject(CommunitySubjectImageCreateDTO c) {
 
         String imageUrl = null;
         if (!c.getImage().isEmpty()) {
@@ -76,7 +78,7 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     public Community save(CommunitySubjectCreateDTO c) {
-        Program program = isPresent(c);
+        Program program = isPresentNI(c);
 
         Community community = Community.builder()
             .title(c.getSubjectName())
@@ -87,7 +89,16 @@ public class CommunityServiceImpl implements CommunityService {
         return communityRepository.save(community);
     }
 
-    private Program isPresent(CommunitySubjectCreateDTO c) {
+    private Program isPresentNI(CommunitySubjectCreateDTO c) {
+        Optional<Program> optionalProgram = programRepository.findById(c.getProgramId());
+        if (optionalProgram.isPresent()) {
+            return optionalProgram.get();
+        } else {
+            throw new NotFoundException(ErrorCode.SAVED_PROGRAM_NOT_FOUND);
+        }
+    }
+
+    private Program isPresent(CommunitySubjectImageCreateDTO c) {
         Optional<Program> optionalProgram = programRepository.findById(c.getProgramId());
         if (optionalProgram.isPresent()) {
             return optionalProgram.get();

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -8,8 +8,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tavebalak.OTTify.common.s3.AWSS3Service;
@@ -173,7 +173,7 @@ public class CommunityServiceImpl implements CommunityService {
 
     @Override
     public CommunitySubjectsDTO findAllSubjects(Pageable pageable) {
-        Page<Community> communities = communityRepository.findCommunitiesBy(pageable);
+        Slice<Community> communities = communityRepository.findCommunitiesBy(pageable);
         List<CommunitySubjectsListDTO> listDTO = communities.stream().map(
             community -> CommunitySubjectsListDTO
                 .builder()
@@ -187,13 +187,13 @@ public class CommunityServiceImpl implements CommunityService {
                 .imageUrl(community.getImageUrl())
                 .build()
         ).collect(Collectors.toList());
-        return CommunitySubjectsDTO.builder().subjectAmount((int) communities.getTotalElements())
-            .list(listDTO).build();
+        return CommunitySubjectsDTO.builder().subjectAmount(communities.getNumberOfElements())
+            .list(listDTO).hasNext(communities.hasNext()).build();
     }
 
     @Override
     public CommunitySubjectsDTO findSingleProgramSubjects(Pageable pageable, Long programId) {
-        Page<Community> communities = communityRepository.findCommunitiesByProgramId(pageable,
+        Slice<Community> communities = communityRepository.findCommunitiesByProgramId(pageable,
             programId);
         List<CommunitySubjectsListDTO> list = communities.stream().map(
             community -> CommunitySubjectsListDTO
@@ -208,8 +208,8 @@ public class CommunityServiceImpl implements CommunityService {
                 .build()
         ).collect(Collectors.toList());
 
-        return CommunitySubjectsDTO.builder().subjectAmount((int) communities.getTotalElements())
-            .list(list).build();
+        return CommunitySubjectsDTO.builder().subjectAmount(communities.getNumberOfElements())
+            .list(list).hasNext(communities.hasNext()).build();
     }
 
     @Override

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -100,7 +100,7 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     @Override
-    public void modifySubject(CommunitySubjectEditDTO c) {
+    public void modifySubject(CommunitySubjectEditDTO c, MultipartFile image) {
         Community community = communityRepository.findById(c.getSubjectId())
             .orElseThrow(() -> new NotFoundException(ErrorCode.COMMUNITY_NOT_FOUND));
 
@@ -111,11 +111,11 @@ public class CommunityServiceImpl implements CommunityService {
         CommunitySubjectImageEditorDTO communitySubjectEditorDTOBuilder = community.toImageEdior();
 
         String imageUrl = null;
-        if (!c.getImage().isEmpty()) {
+        if (!image.isEmpty()) {
             if (community.getImageUrl() != null) {
                 awss3Service.delete(community.getImageUrl());
             }
-            imageUrl = awss3Service.upload(c.getImage(), "discussion-image");
+            imageUrl = awss3Service.upload(image, "discussion-image");
         } else {
             if (community.getImageUrl() != null) {
                 awss3Service.delete(community.getImageUrl());

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -56,6 +56,7 @@ public class CommunityServiceImpl implements CommunityService {
     private final LikedCommunityRepository likedCommunityRepository;
     private final LikedReplyRepository likedReplyRepository;
     private final AWSS3Service awss3Service;
+    private static final String AWS_S3_DISCUSSION_DIR_NAME = "discussion-images";
 
     @Override
     public Community saveSubject(CommunitySubjectImageCreateDTO c) {
@@ -63,7 +64,7 @@ public class CommunityServiceImpl implements CommunityService {
         String imageUrl = null;
         System.out.println(c.getImage());
         if (!c.getImage().isEmpty()) {
-            imageUrl = awss3Service.upload(c.getImage(), "discussion-image");
+            imageUrl = awss3Service.upload(c.getImage(), AWS_S3_DISCUSSION_DIR_NAME);
         }
 
         Program program = isPresent(c);
@@ -120,7 +121,7 @@ public class CommunityServiceImpl implements CommunityService {
             if (community.getImageUrl() != null) {
                 awss3Service.delete(community.getImageUrl());
             }
-            imageUrl = awss3Service.upload(c.getImage(), "discussion-images");
+            imageUrl = awss3Service.upload(c.getImage(), AWS_S3_DISCUSSION_DIR_NAME);
         } else {
             if (community.getImageUrl() != null) {
                 awss3Service.delete(community.getImageUrl());

--- a/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
+++ b/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
@@ -248,7 +248,7 @@ class CommunityControllerTest {
         when(communityService.save(any())).thenReturn(response);
         Community savedCommunity = communityService.save(registerSubjectRequest());
 
-        doNothing().when(communityService).modifySubject(any(), any());
+        doNothing().when(communityService).modifySubject(any());
 
         CommunitySubjectEditDTO editDTO = CommunitySubjectEditDTO.builder()
             .subjectId(savedCommunity.getId())

--- a/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
+++ b/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
@@ -248,7 +248,7 @@ class CommunityControllerTest {
         when(communityService.save(any())).thenReturn(response);
         Community savedCommunity = communityService.save(registerSubjectRequest());
 
-        doNothing().when(communityService).modifySubject(any());
+        doNothing().when(communityService).modifySubject(any(), any());
 
         CommunitySubjectEditDTO editDTO = CommunitySubjectEditDTO.builder()
             .subjectId(savedCommunity.getId())

--- a/src/test/java/tavebalak/OTTify/community/repository/CommunityRepositoryTest.java
+++ b/src/test/java/tavebalak/OTTify/community/repository/CommunityRepositoryTest.java
@@ -1,33 +1,32 @@
 package tavebalak.OTTify.community.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import tavebalak.OTTify.common.constant.Role;
 import tavebalak.OTTify.common.constant.SocialType;
 import tavebalak.OTTify.community.entity.Community;
-
 import tavebalak.OTTify.program.entity.Program;
 import tavebalak.OTTify.program.repository.ProgramRepository;
 import tavebalak.OTTify.user.entity.User;
 import tavebalak.OTTify.user.repository.UserRepository;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE,
-        connection = EmbeddedDatabaseConnection.H2)
+    connection = EmbeddedDatabaseConnection.H2)
 public class CommunityRepositoryTest {
+
     @Autowired
     private CommunityRepository communityRepository;
     @Autowired
@@ -37,47 +36,49 @@ public class CommunityRepositoryTest {
 
     List<Long> numList = new ArrayList<>();
 
-    public void makeList(){
-        for(long i=1;i<=50;i++){
+    public void makeList() {
+        for (long i = 1; i <= 50; i++) {
             numList.add(i);
         }
     }
 
     @Test
     @DisplayName("전체 주제에 대해 페이징된 커뮤니티 목록 확인")
-    public void findCommunitiesBy() throws Exception{
+    public void findCommunitiesBy() throws Exception {
         //given
         User user = userRepository.save(
-                User.builder()
-                        .email("test-email")
-                        .nickName("test-nickName")
-                        .profilePhoto("test-url")
-                        .socialType(SocialType.GOOGLE) // 적절한 값으로 변경
-                        .role(Role.USER) // 적절한 값으로 변경
-                        .build()
+            User.builder()
+                .email("test-email")
+                .nickName("test-nickName")
+                .profilePhoto("test-url")
+                .socialType(SocialType.GOOGLE) // 적절한 값으로 변경
+                .role(Role.USER) // 적절한 값으로 변경
+                .build()
         );
         makeList();
-        for(int i=1;i<=50;i++) communityRepository.save(makeCommunity(user));
+        for (int i = 1; i <= 50; i++) {
+            communityRepository.save(makeCommunity(user));
+        }
 
         //when
         PageRequest pageRequest = PageRequest.of(0, 10, Sort.Direction.DESC, "createdAt");
         userRepository.save(user);
-        Page<Community> communities = communityRepository.findCommunitiesBy(pageRequest);
+        Slice<Community> communities = communityRepository.findCommunitiesBy(pageRequest);
 
         //then
         assertThat(communities.getNumber()).isEqualTo(0);
         assertThat(communities.getSize()).isEqualTo(10);
     }
 
-    public Community makeCommunity(User user){
+    public Community makeCommunity(User user) {
         Collections.shuffle(numList);
         Program program = programRepository.save(Program.builder().title("test-title").build());
 
         return Community.builder()
-                .title("test-title")
-                .content("test-content")
-                .user(user)
-                .program(program)
-                .build();
+            .title("test-title")
+            .content("test-content")
+            .user(user)
+            .program(program)
+            .build();
     }
 }

--- a/src/test/java/tavebalak/OTTify/community/service/CommunityServiceTest.java
+++ b/src/test/java/tavebalak/OTTify/community/service/CommunityServiceTest.java
@@ -162,7 +162,7 @@ public class CommunityServiceTest {
             .build();
         communityService.save(other);
 
-        CommunitySubjectsListDTO build = CommunitySubjectsListDTO.builder()
+        CommunitySubjectsDTO build = CommunitySubjectsDTO.builder()
             .subjectId(1L)
             .programId(5L)
             .createdAt(LocalDateTime.now())
@@ -171,7 +171,7 @@ public class CommunityServiceTest {
             .title(requestDto.getSubjectName())
             .build();
 
-        CommunitySubjectsListDTO build2 = CommunitySubjectsListDTO.builder()
+        CommunitySubjectsDTO build2 = CommunitySubjectsDTO.builder()
             .subjectId(1L)
             .programId(10L)
             .createdAt(LocalDateTime.now())
@@ -188,7 +188,7 @@ public class CommunityServiceTest {
         when(communityRepository.findCommunitiesBy(pageRequest)).thenReturn(page);
 
         //when
-        CommunitySubjectsDTO allSubjects = communityService.findAllSubjects(pageRequest);
+        CommunitySubjectsListDTO allSubjects = communityService.findAllSubjects(pageRequest);
 
         //then
         assertThat(allSubjects).isNotNull();
@@ -213,7 +213,7 @@ public class CommunityServiceTest {
             .build();
         communityService.save(other);
 
-        CommunitySubjectsListDTO build = CommunitySubjectsListDTO.builder()
+        CommunitySubjectsDTO build = CommunitySubjectsDTO.builder()
             .subjectId(1L)
             .programId(5L)
             .createdAt(LocalDateTime.now())
@@ -228,7 +228,7 @@ public class CommunityServiceTest {
             pageRequest, 2);
         //when
         when(communityRepository.findCommunitiesByProgramId(pageRequest, 5L)).thenReturn(page);
-        CommunitySubjectsDTO singleProgramSubjects = communityService.findSingleProgramSubjects(
+        CommunitySubjectsListDTO singleProgramSubjects = communityService.findSingleProgramSubjects(
             pageRequest, 5L);
 
         //then


### PR DESCRIPTION
## 🔥 Related Issue
- Close #110 

## 🏃‍ Task
- 토론페이지 이미지 생성, 수정 구현 관련 📍 관련커밋: {40c12ca7467c9bcd03f728eb18a8e40f58ae45d0}
- 토론페이지 DTO 내용 관련📍 관련커밋: {bf42db57268550930515a610ec01ec5f1801aa63}, {334df72ed1d4fe81372f34c91d0e15173c1c95d6}, {72322d6376f14858292c468bb05747ea59f60d6e}, {7a1e415cebe8a03d4bf3a887adf1a6f7b6c709d7}
이미지 파일을 추가하기 전에 사용하던 토론페이지 주제 생성, 수정 DTO는 테스트에서만 사용되는 DTO입니다 스웨거로 표현할 필요가 없다고 생각해서 스웨거 세팅 내용을 지웠습니다

- 토론페이지 서비스 코드 변경 📍 관련커밋: {d7382042f27f96af536fb1f2f091a1d4fbffcb25}, {a14f55ce80b1085c14aaa592151be8ed0c0f7381}

▶️@RequestPart 대신 @ModelAttribute로 DTO를 받습니다.
이전에는 @RequestPart로 DTO와 MultipartFile를 각각 받는걸로 구현했었는데 스웨거에서 사용이 불편하고 프론트엔드에서 요청할때마다 ContentType을 다르게 설정해주어야한다는 점과 코드 가독성이 스웨거로 인해 떨어진다는 점을 확인해서 변경하게 되었습니다 

▶️ MultipartFile은 null체크를 할때 isEmpty로 확인합니다
== null 로 확인하는 것을 isEmpty로 변경하였습니다

- 무한 스크롤을 위해 Page를 Slice로 변경📍 관련커밋: {438bb5c}

## 📄 Reference
- [파일 + json을 함께 스프링에서 함께 구현하는 방법 개요](https://leeggmin.tistory.com/7)
- [파일 + json을 이용해 form-data로 post 요청을 했음에도 성공하지 않는 경우](https://ssseung.tistory.com/450)
👉 `default value must not be null` 과 같은 DTO @Valid가 작동했던 문제 해결
<img src="https://github.com/TAVE-balak/OTTify-backend/assets/96781855/3c807a89-4e46-425a-9586-6c4ce7df40fc" alt="이미지" width="500" height="auto">

- [@RequestPart를 사용하는 경우 Swagger 상 불편한 점](https://findmypiece.tistory.com/m/348)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?