### PR TITLE
Refactor/#115 add ott img

### DIFF
--- a/src/main/java/tavebalak/OTTify/program/dto/response/OttDTO.java
+++ b/src/main/java/tavebalak/OTTify/program/dto/response/OttDTO.java
@@ -8,14 +8,19 @@ import tavebalak.OTTify.program.entity.Ott;
 @Getter
 @NoArgsConstructor
 public class OttDTO {
+
     @ApiModelProperty(value = "OTT id")
     private Long id;
 
     @ApiModelProperty(value = "OTT 이름")
     private String name;
 
+    @ApiModelProperty(value = "구독 중인 OTT 로고 url")
+    private String subscribeLogoPath;
+
     public OttDTO(Ott ott) {
         this.id = ott.getId();
         this.name = ott.getName();
+        this.subscribeLogoPath = ott.getSubscribeLogoPath();
     }
 }

--- a/src/main/java/tavebalak/OTTify/program/entity/Ott.java
+++ b/src/main/java/tavebalak/OTTify/program/entity/Ott.java
@@ -6,7 +6,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,12 +21,7 @@ public class Ott {
 
     private String name;
     private String logoPath;
+    private String subscribeLogoPath;
 
     private Long tmDbProviderId;
-
-    @Builder
-    public Ott(String name, String logoPath) {
-        this.name = name;
-        this.logoPath = logoPath;
-    }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #115 

## 🏃‍ Task
- DB의 subscribe_logo_path 필드 추가하고 ott 이미지 url 저장 (백엔드>아카이브>create table문에도 반영하겠습니다.)
<img width="1440" alt="image" src="https://github.com/TAVE-balak/OTTify-backend/assets/110277768/cc7cba26-6ecd-4bdd-8875-6a36cd627c2c">

- ott 이미지 반환을 위해 Ott 엔티티와 response dto에 구독 중인 ott 이미지 필드(subscribeLogoPath) 추가📍 관련커밋: {c452e75, ff66305}

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?