### PR TITLE
Bug : 이미지 수정시 기존 이미지 경로 dto 추가(#124)

### DIFF
--- a/src/main/java/tavebalak/OTTify/common/s3/AWSS3Service.java
+++ b/src/main/java/tavebalak/OTTify/common/s3/AWSS3Service.java
@@ -43,8 +43,9 @@ public class AWSS3Service {
             objectMetadata.setContentLength(bytes.length);
             ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
 
-            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, byteArrayInputStream, objectMetadata)
-                .withCannedAcl(CannedAccessControlList.PublicRead));
+            amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName, byteArrayInputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
             throw new InternalServerErrorException(ErrorCode.UPLOAD_FAILED);
         }
@@ -64,5 +65,17 @@ public class AWSS3Service {
         } catch (Exception e) {
             throw new InternalServerErrorException(ErrorCode.FILE_DELETE_FAILED);
         }
+    }
+
+    public boolean isExist(String fileRoute) {
+        boolean isObjectExist = false;
+        int index = fileRoute.indexOf(url);
+        String fileName = fileRoute.substring(index + url.length() + 1);
+        try {
+            isObjectExist = amazonS3Client.doesObjectExist(bucket, fileName);
+        } catch (Exception e) {
+            throw new InternalServerErrorException(ErrorCode.FILE_NOT_FOUND);
+        }
+        return isObjectExist;
     }
 }

--- a/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
+++ b/src/main/java/tavebalak/OTTify/community/dto/request/CommunitySubjectEditDTO.java
@@ -16,12 +16,15 @@ public class CommunitySubjectEditDTO {
     private String subjectName;
     @NotBlank(message = "토론 주제 내용이 비워져 있어서는 안됩니다.")
     private String content;
+    private String imageUrl;
 
     @Builder
-    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content) {
+    public CommunitySubjectEditDTO(Long subjectId, String subjectName, String content,
+        String imageUrl) {
         this.content = content;
         this.subjectName = subjectName;
         this.subjectId = subjectId;
+        this.imageUrl = imageUrl;
     }
 
 }

--- a/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/CommunityServiceImpl.java
@@ -108,21 +108,31 @@ public class CommunityServiceImpl implements CommunityService {
 
         CommunitySubjectImageEditorDTO communitySubjectEditorDTOBuilder = community.toImageEdior();
 
-        String imageUrl = null;
-        if (image != null) {
-            if (community.getImageUrl() != null) {
-                awss3Service.delete(community.getImageUrl());
+        String communityImgUrl = null;
+        String imgPath = c.getImageUrl();
+
+        if (!"".equals(imgPath) && imgPath != null) {
+            if (awss3Service.isExist(imgPath)) {
+                communityImgUrl = imgPath;
             }
-            imageUrl = awss3Service.upload(image, AWS_S3_DISCUSSION_DIR_NAME);
         } else {
-            if (community.getImageUrl() != null) {
-                awss3Service.delete(community.getImageUrl());
+            if (image != null && !image.isEmpty()) {
+                deleteCommunityS3Image(community);
+                communityImgUrl = awss3Service.upload(image, AWS_S3_DISCUSSION_DIR_NAME);
+            } else {
+                deleteCommunityS3Image(community);
             }
         }
 
         CommunitySubjectImageEditorDTO communitySubjectImageEditorDTO = communitySubjectEditorDTOBuilder.changeTitleContentImage(
-            c.getSubjectName(), c.getContent(), imageUrl);
+            c.getSubjectName(), c.getContent(), communityImgUrl);
         community.editImage(communitySubjectImageEditorDTO);
+    }
+
+    public void deleteCommunityS3Image(Community community) {
+        if (community.getImageUrl() != null) {
+            awss3Service.delete(community.getImageUrl());
+        }
     }
 
     public Community modify(CommunitySubjectEditDTO c, User user) {

--- a/src/main/java/tavebalak/OTTify/error/ErrorCode.java
+++ b/src/main/java/tavebalak/OTTify/error/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     SAVED_PROGRAM_NOT_FOUND("저장된 프로그램 정보를 찾을 수 없습니다."),
     COMMUNITY_NOT_FOUND("토론주제를 찾을 수 없습니다."),
     REPLY_NOT_FOUND("댓글을 찾을 수 없습니다."),
+    FILE_NOT_FOUND("이미지 파일을 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
- 보내준 경로에 대해 기존 파일이 없다면 에러코드 추가
- AWSS3Service에서 해당 s3 파일이 존재하는지 여부를 검사하는 함수 추가

## 🔥 Related Issue
- Close #124 

## 🏃‍ Task
- 이미지 수정시, 기존 이미지 경로로 dto에 보낼 수 있도록 필드 변경, 코드변경 📍 관련커밋: {06c257d27918a8e9fb577216cddfe533080eb8df}

## 📄 Reference
- 

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?