### PR TITLE
Refactor: 프로그램 테이블에 index 설정 추가 (#129)

### DIFF
--- a/src/main/java/tavebalak/OTTify/program/entity/Program.java
+++ b/src/main/java/tavebalak/OTTify/program/entity/Program.java
@@ -10,7 +10,9 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +24,7 @@ import tavebalak.OTTify.review.entity.Review;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(indexes = {@Index(name = "IDX_tm_db_program_id_type", columnList = "tmDbProgramId,type")})
 public class Program {
 
     @Id
@@ -33,7 +36,7 @@ public class Program {
     private double averageRating;
     private int reviewCount;
     private Long tmDbProgramId;
-    
+
     @Enumerated(EnumType.STRING)
     private ProgramType type;
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #129 

## 🏃‍ Task

현재 영화 및 tv 프로그램을 
메인 페이지에서 또는 검색 페이지에서 보여줄 떄

각각의 프로그램에 대해서 
DB에 저장되어 있는지 판단하고 저장되어 있지 않으면 DB에 저장하는 로직이 수행되고 있다.

따라서 DB에 프로그램이 쌓이면 쌓일 수록 insert 쿼리 보다는 이게 DB에 저장되어 있는지 판단하는 select 쿼리가 계속 수행이 된다.

더구나 DB에 프로그램 데이터가 쌓이면 쌓일수록 인기있는 프로그램을 검색하는 것은 자주 발생하고 그에 따라  select 쿼리가 많이 수행되고 인기없는 프로그램을 검색하는 것은 드문 일이므로 insert 쿼리가 드물게 수행된다.

이 data 를 
```
where tmdb_program_id=? and type=?
```
로 그냥 찾으면  전체 테이블을 순차적으로 검색하는 Full scan 을 하기 때문에 이 역시 데이터가 쌓이면 쌓일수록 성능이 감소할 수 밖에 없다. 



**따라서 시간이 지남에 따라 insert 쿼리의 숫자는 감소하고
select 쿼리의 숫자는 변함이 없고
update 나 delete 는 일어날 일이 아예 없으며 
데이터가 쌓이면 쌓일 수록 성능이 걱정되었기 때문에**
INDEX 도입을 검토하였다. 


**리뷰가 approve 된다면 DB에 INDEX 세팅하도록 하겠습니다! .**

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?