### PR TITLE
Feat : 대댓글 삭제 버그 수정(#144)

### DIFF
--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -203,12 +203,10 @@ public class CommunityController {
         @ApiImplicitParam(name = "commentId", value = "토론 댓글의 id", required = true, paramType = "path"),
         @ApiImplicitParam(name = "recommentId", value = "토론 대댓글의 id", required = true, paramType = "path")
     })
-    @DeleteMapping("/recomment/{subjectId}/{commentId}/{recommentId}")
+    @DeleteMapping("/recomment/{recommentId}")
     public BaseResponse<String> deleteRecomment(
-        @PathVariable Long subjectId,
-        @PathVariable Long commentId,
         @PathVariable Long recommentId) throws NotFoundException {
-        replyService.deleteRecomment(subjectId, commentId, recommentId);
+        replyService.deleteRecomment(recommentId);
         return BaseResponse.success("성공적으로 토론대댓글을 삭제하였습니다.");
     }
 

--- a/src/main/java/tavebalak/OTTify/community/entity/Reply.java
+++ b/src/main/java/tavebalak/OTTify/community/entity/Reply.java
@@ -79,4 +79,10 @@ public class Reply extends BaseEntity {
     public void edit(ReplyCommentEditorDTO c) {
         this.content = c.getComment();
     }
+
+    public void cancelChildReply(Reply reply) {
+        if (child.contains(reply)) {
+            child.remove(reply);
+        }
+    }
 }

--- a/src/main/java/tavebalak/OTTify/community/service/ReplyService.java
+++ b/src/main/java/tavebalak/OTTify/community/service/ReplyService.java
@@ -20,7 +20,7 @@ public interface ReplyService {
 
     void deleteComment(Long subjectId, Long commentId);
 
-    void deleteRecomment(Long subjectId, Long commentId, Long recommentId);
+    void deleteRecomment(Long recommentId);
 
     List<CommentDTO> getComment(Long commentId);
 }

--- a/src/main/java/tavebalak/OTTify/community/service/ReplyServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/ReplyServiceImpl.java
@@ -148,7 +148,6 @@ public class ReplyServiceImpl implements ReplyService {
         parent.cancelChildReply(savedReply);
 
         likedReplyRepository.deleteAllByReply(savedReply);
-        replyRepository.delete(savedReply);
     }
 
     @Override

--- a/src/main/java/tavebalak/OTTify/community/service/ReplyServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/ReplyServiceImpl.java
@@ -127,6 +127,7 @@ public class ReplyServiceImpl implements ReplyService {
         if (!Objects.equals(savedReply.getUser().getId(), getUser().getId())) {
             throw new BadRequestException(ErrorCode.CAN_NOT_OTHER_COMMENT_DELETE_REQUEST);
         }
+
         likedReplyRepository.deleteAllByReply(savedReply);
         replyRepository.delete(savedReply);
 
@@ -142,6 +143,10 @@ public class ReplyServiceImpl implements ReplyService {
         if (!Objects.equals(savedReply.getUser().getId(), getUser().getId())) {
             throw new BadRequestException(ErrorCode.CAN_NOT_OTHER_COMMENT_DELETE_REQUEST);
         }
+
+        Reply parent = savedReply.getParent();
+        parent.cancelChildReply(savedReply);
+
         likedReplyRepository.deleteAllByReply(savedReply);
         replyRepository.delete(savedReply);
     }

--- a/src/main/java/tavebalak/OTTify/community/service/ReplyServiceImpl.java
+++ b/src/main/java/tavebalak/OTTify/community/service/ReplyServiceImpl.java
@@ -23,6 +23,7 @@ import tavebalak.OTTify.error.exception.NotFoundException;
 import tavebalak.OTTify.error.exception.UnauthorizedException;
 import tavebalak.OTTify.oauth.jwt.SecurityUtil;
 import tavebalak.OTTify.user.entity.User;
+import tavebalak.OTTify.user.repository.LikedReplyRepository;
 import tavebalak.OTTify.user.repository.UserRepository;
 
 @Service
@@ -34,6 +35,7 @@ public class ReplyServiceImpl implements ReplyService {
     private final CommunityRepository communityRepository;
     private final ReplyRepository replyRepository;
     private final UserRepository userRepository;
+    private final LikedReplyRepository likedReplyRepository;
 
     @Override
     public Reply saveComment(ReplyCommentCreateDTO c) {
@@ -125,19 +127,14 @@ public class ReplyServiceImpl implements ReplyService {
         if (!Objects.equals(savedReply.getUser().getId(), getUser().getId())) {
             throw new BadRequestException(ErrorCode.CAN_NOT_OTHER_COMMENT_DELETE_REQUEST);
         }
-
+        likedReplyRepository.deleteAllByReply(savedReply);
         replyRepository.delete(savedReply);
 
     }
 
     @Override
-    public void deleteRecomment(Long subjectId, Long commentId, Long recommentId) {
-        communityRepository.findById(subjectId).orElseThrow(
-            () -> new NotFoundException(ErrorCode.COMMUNITY_NOT_FOUND)
-        );
-        replyRepository.findById(commentId).orElseThrow(
-            () -> new NotFoundException(ErrorCode.REPLY_NOT_FOUND)
-        );
+    public void deleteRecomment(Long recommentId) {
+
         Reply savedReply = replyRepository.findById(recommentId).orElseThrow(
             () -> new NotFoundException(ErrorCode.REPLY_NOT_FOUND)
         );
@@ -145,7 +142,7 @@ public class ReplyServiceImpl implements ReplyService {
         if (!Objects.equals(savedReply.getUser().getId(), getUser().getId())) {
             throw new BadRequestException(ErrorCode.CAN_NOT_OTHER_COMMENT_DELETE_REQUEST);
         }
-
+        likedReplyRepository.deleteAllByReply(savedReply);
         replyRepository.delete(savedReply);
     }
 

--- a/src/main/java/tavebalak/OTTify/user/repository/LikedReplyRepository.java
+++ b/src/main/java/tavebalak/OTTify/user/repository/LikedReplyRepository.java
@@ -3,13 +3,17 @@ package tavebalak.OTTify.user.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import tavebalak.OTTify.community.entity.Reply;
 import tavebalak.OTTify.user.entity.LikedReply;
 
 public interface LikedReplyRepository extends JpaRepository<LikedReply, Long> {
 
-    Optional<LikedReply> findByUserIdAndReplyIdAndCommunityId(Long userId, Long replyId, Long communityId);
+    Optional<LikedReply> findByUserIdAndReplyIdAndCommunityId(Long userId, Long replyId,
+        Long communityId);
 
     List<LikedReply> findByCommunityIdAndReplyId(Long communityId, Long replyId);
 
     int countByCommunityId(Long communityId);
+
+    void deleteAllByReply(Reply reply);
 }

--- a/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
+++ b/src/test/java/tavebalak/OTTify/community/controller/CommunityControllerTest.java
@@ -353,7 +353,7 @@ class CommunityControllerTest {
     @DisplayName("DELETE 토론 대댓글 삭제 컨트롤러 성공")
     public void 대댓글_삭제_성공() throws NotFoundException, Exception {
         //given
-        doNothing().when(replyService).deleteRecomment(anyLong(), anyLong(), anyLong());
+        doNothing().when(replyService).deleteRecomment(anyLong());
 
         //when
         ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
## 🔥 Related Issue
- Close #144

## 🏃‍ Task
- 대댓글 삭제시 Community, 부모 Reply 테이블에서 select 쿼리 제거 📍 관련커밋: {f8724c1647a6feb915c9d91402ff0e7e5fc5225b}

대댓글은 삭제하려는 Community, 부모 Reply가 테이블에 존재하는지 확인을 하고 대댓글을 삭제해주도록 했었습니다
그러면 community테이블, reply 테이블에 select 쿼리가 발생하면서 해당 테이블에 있는 대댓글 엔티티 정보는 영속상태가 됩니다

찾아보니 이렇게 관련된 엔티티를 조회하고나서 **delete 요청시 영속상태에 있는 대댓글 엔티티들로 인해 동시성 문제가 나타지 않도록 jpa에서는 삭제쿼리를 날리지 못하는 거**라고 합니다.

<br/>

> 📍delete쿼리가 나가지 않는다면 해결방법

✅ 양방향 연관관계에 있다면, 삭제 연관관계 편의 메소드 작성해주기
✅ 단방향 연관관계에 있다면, select 쿼리를 제외해서 jpa delete하기

<br/>

++  **댓글 삭제api**에서도 community 테이블 select 후 댓글 삭제를 하는데, 여기서는 delete 쿼리가 정상적으로 나가는게 확인돼요 왜 대댓글에서만 이런 일이 발생하는지 아직은 잘 모르겠습니다

아시는 분 계시면 공유부탁드려요😂

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?