### PR TITLE
Bug: 대댓글 삭제 API delete 쿼리가 나가지 않는 이슈 해결(#144)

### DIFF
--- a/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
+++ b/src/main/java/tavebalak/OTTify/community/controller/CommunityController.java
@@ -199,8 +199,6 @@ public class CommunityController {
     @ApiOperation(value = "토론 대댓글 삭제", notes = "회원이 작성한 토론 주제의 대댓글을 삭제한다.")
     @ApiResponse(code = 200, message = "성공적으로 토론 대댓글을 삭제하였습니다.")
     @ApiImplicitParams({
-        @ApiImplicitParam(name = "subjectId", value = "토론글의 id", required = true, paramType = "path"),
-        @ApiImplicitParam(name = "commentId", value = "토론 댓글의 id", required = true, paramType = "path"),
         @ApiImplicitParam(name = "recommentId", value = "토론 대댓글의 id", required = true, paramType = "path")
     })
     @DeleteMapping("/recomment/{recommentId}")


### PR DESCRIPTION
## 🔥 Related Issue
- Close #144 

## 🏃‍ Task
- 사용하지 않는 Swagger ApiImplicitParam 제거 📍 관련커밋: {b53ad2c2ec2f33b7bbe538ae72c10621e6ce316d}

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?