### PR TITLE
Refactor: 데이터 중복 시 예외 처리 (#155)

### DIFF
--- a/src/main/java/tavebalak/OTTify/error/ErrorCode.java
+++ b/src/main/java/tavebalak/OTTify/error/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
      * 500 Internal Server Error
      */
     INTERNAL_SERVER_ERROR("서버 내부 오류입니다."),
+    DATA_SAVING_ERROR("데이터 저장중입니다. 새로 고침해주세요"),
     UPLOAD_FAILED("업로드에 실패하였습니다."),
     FILE_DELETE_FAILED("파일 삭제에 실패하였습니다.");
 

--- a/src/test/java/tavebalak/OTTify/ProgramTest.java
+++ b/src/test/java/tavebalak/OTTify/ProgramTest.java
@@ -1,0 +1,41 @@
+package tavebalak.OTTify;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import tavebalak.OTTify.program.service.ProgramShowAndSaveService;
+
+@SpringBootTest
+public class ProgramTest {
+
+    @Autowired
+    private ProgramShowAndSaveService programShowAndSaveService;
+
+    @Test
+    @Rollback(value = false)
+    @Transactional
+    void testing() throws InterruptedException {
+
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        executorService.execute(() -> {
+            programShowAndSaveService.searchByName("겨울");
+            latch.countDown();
+        });
+
+        executorService.execute(() -> {
+            programShowAndSaveService.searchByMovieName("겨울", 1);
+            latch.countDown();
+        });
+
+        latch.await();
+
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #155 

## 🏃‍ Task
- 작업사항 작성 📍 

unique 제약 조건을 이용해서 데이터 중복 제거하기 


데이터를 짧은 시간에 2번 요청했을 때 이미 저장되지 않은 프로그램의 경우 중복 저장이 되는 문제가 있었습니다. 

이를 해결하기 위해 Lock 을 적용하는 방법을 시도했는데 그것보다  더 효율적인 

unique 제약 조건을 활용해서 중복 저장이 되는 문제를 방지합니다.

Approve 가 난다면 DB에 

```
ALTER TABLE `program`
ADD CONSTRAINT `unique_tm_db_program_id_type`
UNIQUE (`tm_db_program_id`, `type`);
```

을 통해 unique 제약 조건을 추가하겠습니다. 

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?